### PR TITLE
Add iPhoto sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     nut \
     openssh-client \
     usbutils \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Set up NUT user and permissions

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ To configure the server behavior, add a config file to: `~/.bungalo/config.toml`
      --device=/dev/bus/usb \
      -v ~/.bungalo:/root/.bungalo \
      -v /dev/bus/usb:/dev/bus/usb \
+     --cap-add=SYS_ADMIN \
+     --device /dev/fuse \
      bungalo
    ```
 
@@ -79,5 +81,7 @@ To configure the server behavior, add a config file to: `~/.bungalo/config.toml`
         --device=/dev/bus/usb \
         -v ~/.bungalo:/root/.bungalo \
         -v /dev/bus/usb:/dev/bus/usb \
+        --cap-add=SYS_ADMIN \
+        --device /dev/fuse \
         -it bungalo /bin/bash
     ```

--- a/bungalo/backups/iphoto.py
+++ b/bungalo/backups/iphoto.py
@@ -47,7 +47,7 @@ class iPhotoSync:
         self,
         username: str,
         password: str,
-        client_id: str,
+        client_id: str | None,
         album_name: str,
         photo_size: AssetVersionSize,
         output_path: Path,

--- a/bungalo/backups/iphoto.py
+++ b/bungalo/backups/iphoto.py
@@ -1,0 +1,339 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from queue import Queue
+from shutil import copyfile
+from tempfile import TemporaryDirectory
+from typing import Any, Iterator
+
+from icloudpd import download, exif_datetime
+from icloudpd.authentication import TwoStepAuthRequiredError, authenticator
+from icloudpd.paths import clean_filename
+from tzlocal import get_localzone
+
+from bungalo.backups.nas import mount_smb
+from bungalo.config import BungaloConfig
+from bungalo.io import progress_bar
+from bungalo.logger import CONSOLE, LOGGER
+
+FOLDER_STRUCTURE = "{:%Y/%m/%d}"
+
+
+@dataclass
+class PhotoContext:
+    photo: Any
+    created_date: datetime
+    output_path: Path
+
+
+class iPhotoSync:
+    """
+    Syncer from remote iCloud photo library to local directory.
+
+    Downloads photos from a specified iCloud album with proper date-based
+    organization, EXIF metadata preservation, and concurrent operations.
+    """
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        client_id: str,
+        album_name: str,
+        photo_size: str,
+        output_path: Path,
+        concurrency: int = 10,
+    ) -> None:
+        """
+        Initialize the iPhoto sync engine.
+
+        :param username: iCloud account username/email
+        :param password: iCloud account password
+        :param client_id: Client identifier for iCloud API
+        :param album_name: Name of the album to sync
+        :param photo_size: Size/quality of photos to download (e.g., "original")
+        :param output_path: Base directory where photos will be saved
+        :param concurrency: Number of concurrent download operations
+        """
+        self.username = username
+        self.password = password
+        self.client_id = client_id
+        self.album_name = album_name
+        self.photo_size = photo_size
+        self.output_path = output_path
+        self.concurrency = concurrency
+
+        self._completed_photos = 0
+
+    async def sync(self) -> None:
+        """
+        Synchronize photos from iCloud to the local filesystem.
+
+        Connects to iCloud, fetches photos from the specified album,
+        and downloads them with proper organization and metadata.
+        Uses asyncio for non-blocking concurrent downloads with a queue system
+        to control resource usage.
+        """
+        icloud = await self.icloud_login_async()
+        CONSOLE.print("Getting photo metadata from album...")
+        photos = icloud.photos.albums[self.album_name]
+        CONSOLE.print(f"Found {len(photos)} photos, starting to process metadata...")
+
+        # Create a task to populate the queue in background
+        queue: Queue[PhotoContext] = Queue()
+        producer_task = asyncio.create_task(self._populate_queue(photos, queue))
+
+        # Create worker tasks to process photos
+        workers = [
+            asyncio.create_task(self._worker(icloud, i, queue))
+            for i in range(self.concurrency)
+        ]
+
+        # Setup progress tracking
+        progress_task = asyncio.create_task(self._track_progress(len(photos)))
+
+        # Wait for all tasks to complete
+        await asyncio.gather(producer_task, *workers, progress_task)
+
+        CONSOLE.print("Photo sync completed successfully")
+
+    async def _populate_queue(self, photos: Any, queue: Queue[PhotoContext]) -> None:
+        """
+        Populate the work queue with photo contexts.
+
+        :param photos: Collection of photo objects from iCloud
+        """
+
+        def _inner():
+            count = 0
+            for photo in self.iter_photos(photos):
+                queue.put(photo)
+                count += 1
+            CONSOLE.print(f"Added {count} photos to processing queue")
+
+        # Run iter_photos in a separate thread to avoid blocking
+        await asyncio.to_thread(_inner)
+
+    async def _worker(
+        self, icloud: Any, worker_id: int, queue: Queue[PhotoContext]
+    ) -> None:
+        """
+        Worker task that processes photos from the queue.
+
+        :param icloud: Authenticated iCloud service instance
+        :param worker_id: Unique ID for this worker
+        """
+
+        def _inner():
+            while True:
+                # Get a photo to process from the queue
+                photo_context = queue.get()
+                if photo_context is None:
+                    break
+
+                try:
+                    # Process the photo
+                    self.sync_photo(icloud, photo_context)
+                except Exception as e:
+                    LOGGER.error(
+                        f"Worker {worker_id} error processing {photo_context.output_path.name}: {str(e)}"
+                    )
+                finally:
+                    # Mark the task as done
+                    queue.task_done()
+                    self._completed_photos += 1
+
+        # Run iter_photos in a separate thread to avoid blocking
+        await asyncio.to_thread(_inner)
+
+    async def _track_progress(self, total_photos: int) -> None:
+        """
+        Track and display progress of the photo sync operation.
+
+        :param total_photos: Total number of photos to be processed
+        """
+        processed = 0
+
+        async with progress_bar(total=total_photos, description="Syncing photos") as (
+            pb,
+            task,
+        ):
+            # Update progress bar with the new number of completed items
+            diff = self._completed_photos - processed
+            if diff:
+                pb.update(task, advance=diff)
+                processed = self._completed_photos
+
+            # Wait a bit before checking again
+            await asyncio.sleep(0.5)
+
+    def iter_photos(self, photos: Any) -> Iterator[PhotoContext]:
+        """
+        Generate PhotoContext objects for each relevant photo.
+
+        :param photos: Collection of photo objects from iCloud
+        :return: Iterator yielding PhotoContext objects for each photo with proper paths
+
+        Skips non-photo/video items and handles timezone conversion.
+        """
+        for photo in photos:
+            filename = clean_filename(photo.filename)
+
+            if photo.item_type not in {"image", "movie"}:
+                CONSOLE.print(
+                    f"Skipping {filename}, only downloading photos and videos. "
+                    f"(Item type was: {photo.item_type})"
+                )
+                continue
+
+            try:
+                created_date = photo.created.astimezone(get_localzone())
+            except (ValueError, OSError):
+                CONSOLE.print(
+                    f"Could not convert photo created date to local timezone ({photo.created})"
+                )
+                created_date = photo.created
+
+            # The remote path should be prefixed with the date
+            date_path = FOLDER_STRUCTURE.format(created_date)
+
+            yield PhotoContext(
+                photo=photo,
+                created_date=created_date,
+                output_path=self.output_path / date_path / filename,
+            )
+
+    def sync_photo(self, icloud: Any, photo_payload: PhotoContext) -> None:
+        """
+        Download and save a single photo to its destination.
+
+        :param icloud: Authenticated iCloud service instance
+        :param photo_payload: Photo metadata and destination information
+
+        Skips photos that already exist at the destination path.
+        Downloads to a temporary location before copying to final destination.
+        """
+        # Check if this photo has already been added to the remote
+        if photo_payload.output_path.exists():
+            return
+
+        # Create parent directory if it doesn't exist
+        photo_payload.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with TemporaryDirectory() as download_root:
+            download_path = Path(download_root) / "content"
+
+            start_time = datetime.now()
+            # Download media directly without async wrapping
+            download_result = download.download_media(
+                icloud,
+                photo_payload.photo,
+                download_path,
+                self.photo_size,
+            )
+            LOGGER.debug("Download Duration (ms)", datetime.now() - start_time)
+
+            # Process EXIF data directly
+            self.inject_exif(
+                photo_payload.photo,
+                download_result,
+                download_path,
+                photo_payload.created_date,
+            )
+
+            # Copy the file directly
+            copyfile(download_path, photo_payload.output_path)
+
+    def inject_exif(
+        self,
+        photo: Any,
+        download_result: bool,
+        download_path: Path,
+        created_date: datetime,
+        set_exif_datetime: bool = True,
+    ) -> None:
+        """
+        Add EXIF metadata to downloaded photos.
+
+        :param photo: Photo object from iCloud
+        :param download_result: Whether download was successful
+        :param download_path: Path to the downloaded file
+        :param created_date: Original creation date to set
+        :param set_exif_datetime: Whether to set the EXIF datetime
+
+        Sets creation date in EXIF metadata for JPEGs and
+        updates file modification time to match original.
+        """
+        if not download_result:
+            return
+
+        if (
+            set_exif_datetime
+            and (clean_filename(photo.filename).lower().endswith((".jpg", ".jpeg")))
+            and not exif_datetime.get_photo_exif(download_path)
+        ):
+            exif_datetime.set_photo_exif(
+                download_path,
+                created_date.strftime("%Y:%m:%d %H:%M:%S"),
+            )
+        download.set_utime(download_path, created_date)
+
+    def icloud_login(self, cookie_directory: str = "~/.pyicloud") -> Any:
+        """
+        Authenticate with iCloud services.
+
+        :param cookie_directory: Directory to store authentication cookies
+        :return: Authenticated iCloud service instance
+        :raises Exception: If two-factor authentication is required
+        """
+        try:
+            return authenticator("com")(
+                self.username,
+                self.password,
+                cookie_directory,
+                raise_error_on_2sa=False,
+                client_id=self.client_id,
+            )
+        except TwoStepAuthRequiredError:
+            raise Exception("Two-step authentication required")
+
+    async def icloud_login_async(self, cookie_directory: str = "~/.pyicloud") -> Any:
+        """
+        Authenticate with iCloud services asynchronously.
+
+        :param cookie_directory: Directory to store authentication cookies
+        :return: Authenticated iCloud service instance
+        :raises Exception: If two-factor authentication is required
+        """
+        # Run authentication in a thread to avoid blocking
+        return await asyncio.to_thread(self.icloud_login, cookie_directory)
+
+
+async def main(config: BungaloConfig) -> None:
+    """
+    Main entry point for iPhoto backup process.
+
+    :param config: Bungalo configuration containing NAS connection details
+
+    Mounts NAS drive using SMB and performs photo synchronization.
+    """
+    with mount_smb(
+        server=config.nas.ip_address,
+        share=config.nas.drive_name,
+        username=config.nas.username,
+        password=config.nas.password,
+        domain=config.nas.domain,
+    ) as mount_dir:
+        CONSOLE.print(f"SMB share mounted at: {mount_dir}")
+
+        iphoto_sync = iPhotoSync(
+            username=config.iphoto.username,
+            password=config.iphoto.password,
+            client_id=config.iphoto.client_id,
+            album_name=config.iphoto.album_name,
+            photo_size=config.iphoto.photo_size,
+            output_path=Path(mount_dir) / config.iphoto.output_directory,
+        )
+
+        await iphoto_sync.sync()

--- a/bungalo/backups/iphoto.py
+++ b/bungalo/backups/iphoto.py
@@ -325,6 +325,14 @@ class iPhotoSync:
                 False,
                 self.client_id,
             )
+        except PyiCloudFailedLoginException as e:
+            if "503" in str(e):
+                CONSOLE.print(f"503 detected, this might be a transient error because of rate limiting.")
+                CONSOLE.print("https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/970")
+                CONSOLE.print("https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1078")
+                raise Exception("503 detected")
+            else:
+                raise e
         except TwoStepAuthRequiredError:
             raise Exception("Two-step authentication required")
 

--- a/bungalo/backups/nas.py
+++ b/bungalo/backups/nas.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, Generator, Optional, TypeVar, Union
+
+from bungalo.logger import CONSOLE
+
+T = TypeVar("T")
+R = TypeVar("R")
+
+
+@contextmanager
+def mount_smb(
+    server: str,
+    share: str = "",  # Empty string for root share
+    username: str = "",
+    password: str = "",
+    domain: Optional[str] = None,
+    mount_options: Optional[Dict[str, Any]] = None,
+    mount_point: Optional[Union[str, Path]] = None,
+) -> Generator[Path, None, None]:
+    """
+    Context manager that temporarily mounts an SMB share and yields the mount path.
+    Linux-only implementation using mount.cifs.
+
+    Args:
+        server: The SMB server hostname or IP address (e.g., "192.168.1.172")
+        share: The name of the share on the server. This is the specific folder being shared.
+               For example "backup", "media", "documents", etc. Use empty string for root.
+        username: Username for authentication. Use empty string for guest/anonymous access.
+        password: Password for authentication. Use empty string for guest/anonymous access.
+        domain: Optional Windows domain for authentication (often not needed for home networks)
+        mount_options: Optional dictionary of additional mount options
+        mount_point: Optional specific mount point, if not provided a temporary directory will be created
+
+    Yields:
+        Path object pointing to the mounted directory
+
+    Raises:
+        subprocess.CalledProcessError: If mounting or unmounting fails
+
+    Note:
+        If you only have an SMB URL like "smb://192.168.1.172", the server is "192.168.1.172"
+        and you'll need to know which share to connect to on that server.
+    """
+    is_temp_dir = mount_point is None
+
+    try:
+        if is_temp_dir:
+            # Create a temporary directory for mounting
+            temp_dir = tempfile.TemporaryDirectory()
+            mount_point = temp_dir.name
+
+        mount_path = Path(mount_point)
+        os.makedirs(mount_path, exist_ok=True)
+
+        # Prepare mount options for Linux
+        options_str = "vers=3.0"  # Default to SMB3 protocol
+
+        if username:
+            options_str += f",username={username}"
+            if password:
+                options_str += f",password={password}"
+        else:
+            options_str += ",guest"
+
+        if domain:
+            options_str += f",domain={domain}"
+
+        # Add any additional options
+        if mount_options:
+            for key, value in mount_options.items():
+                options_str += f",{key}={value}"
+
+        # Prepare and execute mount.cifs command
+        cmd = [
+            "mount",
+            "-t",
+            "cifs",
+            f"//{server}/{share}",
+            str(mount_path),
+            "-o",
+            options_str,
+        ]
+        subprocess.run(cmd, check=True, capture_output=True)
+
+        # Yield the mount point
+        yield mount_path
+
+    finally:
+        # Unmount and clean up
+        try:
+            if os.path.ismount(str(mount_path)):
+                subprocess.run(["umount", str(mount_path)], check=True)
+        except Exception as e:
+            CONSOLE.print(f"Warning: Failed to unmount {mount_path}: {e}")
+
+        # Clean up the temporary directory if we created one
+        if is_temp_dir:
+            temp_dir.cleanup()

--- a/bungalo/cli.py
+++ b/bungalo/cli.py
@@ -4,6 +4,7 @@ from tomllib import loads as toml_loads
 
 from click import group
 
+from bungalo.backups.iphoto import main as iphoto_main
 from bungalo.config import BungaloConfig
 from bungalo.constants import DEFAULT_CONFIG_FILE
 from bungalo.io import async_to_sync
@@ -32,6 +33,14 @@ async def auto_shutdown():
     """Launch a daemon to monitor battery status and shutdown local machines when low."""
     config = get_config()
     await battery_main(config)
+
+
+@cli.command()
+@async_to_sync
+async def iphoto_backup():
+    """Backup iPhoto library to NAS."""
+    config = get_config()
+    await iphoto_main(config)
 
 
 @cli.command()

--- a/bungalo/cli.py
+++ b/bungalo/cli.py
@@ -24,6 +24,7 @@ async def run_all():
     config = get_config()
     await asyncio.gather(
         battery_main(config),
+        iphoto_main(config),
     )
 
 

--- a/bungalo/config.py
+++ b/bungalo/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, Field
 
 
 class ManagedHardware(BaseSettings):
@@ -16,7 +16,25 @@ class NutConfig(BaseSettings):
     startup_threshold: int = 50  # Start back up when battery above 50%
 
 
+class NASConfig(BaseSettings):
+    ip_address: str
+    drive_name: str
+    username: str
+    password: str
+    domain: str = "WORKGROUP"
+
+
+class iPhotoBackupConfig(BaseSettings):
+    username: str
+    password: str
+    client_id: str
+    album_name: str = "All Photos"
+    photo_size: str = "original"
+
+
 class BungaloConfig(BaseSettings):
-    root: RootConfig
-    nut: NutConfig = NutConfig()
+    root: RootConfig = Field(default_factory=RootConfig)
+    nut: NutConfig = Field(default_factory=NutConfig)
+    nas: NASConfig = Field(default_factory=NASConfig)
+    iphoto: iPhotoBackupConfig = Field(default_factory=iPhotoBackupConfig)
     managed_hardware: list[ManagedHardware] = []

--- a/bungalo/config.py
+++ b/bungalo/config.py
@@ -28,7 +28,7 @@ class NASConfig(BaseSettings):
 class iPhotoBackupConfig(BaseSettings):
     username: str
     password: str
-    client_id: str
+    client_id: str | None = None
     album_name: str = "All Photos"
     photo_size: str = "original"
     output_directory: str

--- a/bungalo/config.py
+++ b/bungalo/config.py
@@ -1,4 +1,5 @@
-from pydantic_settings import BaseSettings, Field
+from pydantic import Field
+from pydantic_settings import BaseSettings
 
 
 class ManagedHardware(BaseSettings):
@@ -30,11 +31,12 @@ class iPhotoBackupConfig(BaseSettings):
     client_id: str
     album_name: str = "All Photos"
     photo_size: str = "original"
+    output_directory: str
 
 
 class BungaloConfig(BaseSettings):
-    root: RootConfig = Field(default_factory=RootConfig)
+    root: RootConfig
     nut: NutConfig = Field(default_factory=NutConfig)
-    nas: NASConfig = Field(default_factory=NASConfig)
-    iphoto: iPhotoBackupConfig = Field(default_factory=iPhotoBackupConfig)
+    nas: NASConfig
+    iphoto: iPhotoBackupConfig
     managed_hardware: list[ManagedHardware] = []

--- a/bungalo/io.py
+++ b/bungalo/io.py
@@ -1,6 +1,16 @@
 import asyncio
+from contextlib import contextmanager
 from functools import wraps
 from typing import Any, Callable, Coroutine, ParamSpec, TypeVar
+
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TaskProgressColumn,
+    TextColumn,
+    TimeRemainingColumn,
+)
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -14,3 +24,20 @@ def async_to_sync(async_fn: Callable[P, Coroutine[Any, Any, T]]) -> Callable[P, 
         return result
 
     return wrapper
+
+
+@contextmanager
+def progress_bar(
+    description: str = "Processing",
+    total: int | None = None,
+):
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[bold blue]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        TextColumn("•"),
+        TimeRemainingColumn(),
+    ) as progress:
+        task = progress.add_task(description, total=total)
+        yield (progress, task)

--- a/config.example.toml
+++ b/config.example.toml
@@ -20,5 +20,4 @@ slack_webhook_url = "https://hooks.slack.com/..."
 [iphoto]
   username = "your_username"
   password = "your_password"
-  client_id = "your_client_id"
   output_directory = "iphoto"

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,3 +10,15 @@ slack_webhook_url = "https://hooks.slack.com/..."
   name = "Dream Machine"
   local_ip = "192.168.1.1"
   username = "root"
+
+[nas]
+  ip_address = "192.168.1.172"
+  drive_name = "NAS"
+  username = "root"
+  password = "password"
+
+[iphoto]
+  username = "your_username"
+  password = "your_password"
+  client_id = "your_client_id"
+  output_directory = "iphoto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "wakeonlan>=3.1.0",
     "pydantic-settings>=2.8.1",
     "httpx>=0.28.1",
+    "icloudpd>=1.27.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ section-order = [
     "local-folder",
 ]
 combine-as-imports = true
+
+[tool.uv.sources]
+icloudpd = { git = "https://github.com/piercefreeman/icloud_photos_downloader" }

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,9 @@
 # Pull the latest container
 docker pull ghcr.io/piercefreeman/bungalo:latest
 
+# We require cifs to be loaded for the NAS backup to work
+sudo modprobe cifs
+
 # Shutdown the current container if it exists
 docker rm -f bungalo || true
 
@@ -15,6 +18,8 @@ docker run -d \
      --privileged \
      --network host \
      --device=/dev/bus/usb \
+     --cap-add=SYS_ADMIN \
+     --device /dev/fuse \
      -v ~/.bungalo:/root/.bungalo \
      -v /dev/bus/usb:/dev/bus/usb \
      ghcr.io/piercefreeman/bungalo:latest

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458 },
+]
+
+[[package]]
 name = "bungalo"
 version = "0.1.0"
 source = { editable = "." }
@@ -66,7 +75,7 @@ requires-dist = [
     { name = "asyncssh", specifier = ">=2.14.2" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "icloudpd", specifier = ">=1.27.4" },
+    { name = "icloudpd", git = "https://github.com/piercefreeman/icloud_photos_downloader" },
     { name = "nut2", specifier = ">=2.1.1" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
@@ -83,11 +92,11 @@ dev = [
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2024.12.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/bd/1d41ee578ce09523c81a15426705dd20969f5abf006d1afe8aeff0dd776a/certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db", size = 166010 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+    { url = "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56", size = 164927 },
 ]
 
 [[package]]
@@ -121,6 +130,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469 },
     { url = "https://files.pythonhosted.org/packages/bf/ee/f94057fa6426481d663b88637a9a10e859e492c73d0384514a17d78ee205/cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d", size = 172475 },
     { url = "https://files.pythonhosted.org/packages/7c/fc/6a8cb64e5f0324877d503c854da15d76c1e50eb722e320b15345c4d0c6de/cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a", size = 182009 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
 ]
 
 [[package]]
@@ -180,6 +224,22 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/50/dff6380f1c7f84135484e176e0cac8690af72fa90e932ad2a0a60e28c69b/flask-3.1.0.tar.gz", hash = "sha256:5f873c5184c897c8d9d1b05df1e3d01b14910ce69607a117bd3277098a5836ac", size = 680824 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/47/93213ee66ef8fae3b93b3e29206f6b251e65c97bd91d8e1c5596ef15af0a/flask-3.1.0-py3-none-any.whl", hash = "sha256:d667207822eb83f1c4b50949b1623c8fc8d51f2341d65f72e1a1815397551136", size = 102979 },
+]
+
+[[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -219,13 +279,25 @@ wheels = [
 [[package]]
 name = "icloudpd"
 version = "1.27.4"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/32/cb34e67be973edd919d36dc019090971c72bb060dba9520c66c85c597296/icloudpd-1.27.4-py2.py3-none-macosx_13_0_x86_64.macosx_13_0_arm64.whl", hash = "sha256:23f178235b6c6263eba1e871bfd96ce9c8fcbde0897e9a9a025ee8a0f8d7359f", size = 28146862 },
-    { url = "https://files.pythonhosted.org/packages/6c/03/ae65e457964272051a52ad21584c1a956d55f7753d1a4b57de09ad16c6f5/icloudpd-1.27.4-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fdc249f18153bae7a2fff8e6f80f7f36e165743f2413186a548b80838a4b003", size = 63124023 },
-    { url = "https://files.pythonhosted.org/packages/22/03/82791a6bf4d7a06492aa94f6398d86cad23cf3c3266664a956dd39d5438a/icloudpd-1.27.4-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c2a5aa980854b9c8c06d54233b048ad8b8550a579cf2c0b36926f46fda1a4da", size = 60615943 },
-    { url = "https://files.pythonhosted.org/packages/84/5c/5ba73a6b8b21b65609b58ec12992bd1145221d16f70adbd38d22902779db/icloudpd-1.27.4-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21484450ba3aacdc357b2dc1cef2bd294041298d6a872a8be4ac53bc87846ef0", size = 65984457 },
-    { url = "https://files.pythonhosted.org/packages/0b/79/6ae47efd142a0e4d84048facc835812cf03c82b1fba1b6fbd8bb2032b6e4/icloudpd-1.27.4-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1b9fdb72dfc7fa83c5e586ef7143858d31602224fde02aca85fe2cab43eeb920", size = 34811609 },
+source = { git = "https://github.com/piercefreeman/icloud_photos_downloader#49257a222fbad45c1e91ba6b9da14c589ada7cf6" }
+dependencies = [
+    { name = "certifi" },
+    { name = "click" },
+    { name = "flask" },
+    { name = "keyring" },
+    { name = "keyrings-alt" },
+    { name = "piexif" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "schema" },
+    { name = "six" },
+    { name = "srp" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+    { name = "tzlocal" },
+    { name = "urllib3" },
+    { name = "waitress" },
 ]
 
 [[package]]
@@ -247,6 +319,99 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234 },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777 },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz", hash = "sha256:9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3", size = 13912 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl", hash = "sha256:f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4", size = 6825 },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz", hash = "sha256:70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d", size = 19159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl", hash = "sha256:ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649", size = 10187 },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010 },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
+name = "keyring"
+version = "25.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz", hash = "sha256:0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66", size = 62750 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl", hash = "sha256:552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd", size = 39085 },
+]
+
+[[package]]
+name = "keyrings-alt"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/7b/e3bf53326e0753bee11813337b1391179582ba5c6851b13e0d9502d15a50/keyrings_alt-5.0.2.tar.gz", hash = "sha256:8f097ebe9dc8b185106502b8cdb066c926d2180e13b4689fd4771a3eab7d69fb", size = 29229 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/0d/9c59313ab43d0858a9a665e80763bd830dc78d5f379afc3815e123c486c2/keyrings.alt-5.0.2-py3-none-any.whl", hash = "sha256:6be74693192f3f37bbb752bfac9b86e6177076b17d2ac12a390f1d6abff8ac7c", size = 17930 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -259,12 +424,59 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3b/7fa1fe835e2e93fd6d7b52b2f95ae810cf5ba133e1845f726f5a992d62c2/more-itertools-10.6.0.tar.gz", hash = "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b", size = 125009 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/62/0fe302c6d1be1c777cab0616e6302478251dfbf9055ad426f5d0def75c89/more_itertools-10.6.0-py3-none-any.whl", hash = "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89", size = 63038 },
 ]
 
 [[package]]
@@ -289,6 +501,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "piexif"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/84/a3f25cec7d0922bf60be8000c9739d28d24b6896717f44cc4cfb843b1487/piexif-1.1.3.zip", hash = "sha256:83cb35c606bf3a1ea1a8f0a25cb42cf17e24353fd82e87ae3884e74a302a5f1b", size = 1011134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/d8/6f63147dd73373d051c5eb049ecd841207f898f50a5a1d4378594178f6cf/piexif-1.1.3-py2.py3-none-any.whl", hash = "sha256:3bc435d171720150b81b15d27e05e54b8abbde7b4242cddd81ef160d283108b6", size = 20691 },
 ]
 
 [[package]]
@@ -417,12 +638,57 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
+]
+
+[[package]]
+name = "pytz"
+version = "2024.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/31/3c70bf7603cc2dca0f19bdc53b4537a797747a58875b552c8c413d963a3f/pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a", size = 319692 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/c3/005fcca25ce078d2cc29fd559379817424e94885510568bc1bc53d7d5846/pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725", size = 508002 },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
 ]
 
 [[package]]
@@ -464,6 +730,37 @@ wheels = [
 ]
 
 [[package]]
+name = "schema"
+version = "0.7.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/01/0ea2e66bad2f13271e93b729c653747614784d3ebde219679e41ccdceecd/schema-0.7.7.tar.gz", hash = "sha256:7da553abd2958a19dc2547c388cde53398b39196175a9be59ea1caf5ab0a1807", size = 44245 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/1b/81855a88c6db2b114d5b2e9f96339190d5ee4d1b981d217fa32127bb00e0/schema-0.7.7-py2.py3-none-any.whl", hash = "sha256:5d976a5b50f36e74e2157b47097b60002bd4d42e65425fcc9c9befadb4255dde", size = 18632 },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz", hash = "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77", size = 19739 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl", hash = "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99", size = 15221 },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -473,12 +770,36 @@ wheels = [
 ]
 
 [[package]]
-name = "typing-extensions"
-version = "4.13.2"
+name = "srp"
+version = "1.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/fb/9210875dd162d3977580407b1c5ce6e779e770b8197a0de76819144a9755/srp-1.0.22.tar.gz", hash = "sha256:f330d0ec7387e2ac8577487b164963155d4a031bca6e2024f1b0930eb92baa5d", size = 22472 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
+    { url = "https://files.pythonhosted.org/packages/89/75/5352c3ebd26e7d119042ae8de07354435a19c77fa2b44058fa97a1416783/srp-1.0.22-py3-none-any.whl", hash = "sha256:35aa8af053285a35683eb37182dcb2e46dbd85c7075d28e139f200d6bf16ea43", size = 25347 },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]
 
 [[package]]
@@ -494,10 +815,61 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz", hash = "sha256:8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e", size = 30201 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/3f/c4c51c55ff8487f2e6d0e618dba917e3c3ee2caae6cf0fbb59c9b1876f2e/tzlocal-5.2-py3-none-any.whl", hash = "sha256:49816ef2fe65ea8ac19d19aa7a1ae0551c834303d5014c6d5a62e4cbda8047b8", size = 17859 },
+]
+
+[[package]]
+name = "urllib3"
+version = "1.26.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e8/6ff5e6bc22095cfc59b6ea711b687e2b7ed4bdb373f7eeec370a97d7392f/urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32", size = 307380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e", size = 144225 },
+]
+
+[[package]]
+name = "waitress"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/cb/04ddb054f45faa306a230769e868c28b8065ea196891f09004ebace5b184/waitress-3.0.2.tar.gz", hash = "sha256:682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f", size = 179901 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/57/a27182528c90ef38d82b636a11f606b0cbb0e17588ed205435f8affe3368/waitress-3.0.2-py3-none-any.whl", hash = "sha256:c56d67fd6e87c2ee598b76abdd4e96cfad1f24cacdea5078d382b1f9d7b5ed2e", size = 56232 },
+]
+
+[[package]]
 name = "wakeonlan"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/98/b92125baeaf67b3a838bfdb4ac4e685c793ce2771686b10df44275e424a4/wakeonlan-3.1.0.tar.gz", hash = "sha256:aa12edc2587353528a89ad58a54c63212dc2a12226c186b7fcc02caa162cd962", size = 4242 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/47/99a02d847104bbc08d10b147e77593c127c405774fa7f5247afd152754e5/wakeonlan-3.1.0-py3-none-any.whl", hash = "sha256:9414da87f48e5dc8a1bb0fa15aba5a0079cfd014231c4cc8e6f2477a0d078c7e", size = 4984 },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,7 @@ dependencies = [
     { name = "asyncssh" },
     { name = "click" },
     { name = "httpx" },
+    { name = "icloudpd" },
     { name = "nut2" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -65,6 +66,7 @@ requires-dist = [
     { name = "asyncssh", specifier = ">=2.14.2" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "icloudpd", specifier = ">=1.27.4" },
     { name = "nut2", specifier = ">=2.1.1" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
@@ -212,6 +214,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "icloudpd"
+version = "1.27.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/32/cb34e67be973edd919d36dc019090971c72bb060dba9520c66c85c597296/icloudpd-1.27.4-py2.py3-none-macosx_13_0_x86_64.macosx_13_0_arm64.whl", hash = "sha256:23f178235b6c6263eba1e871bfd96ce9c8fcbde0897e9a9a025ee8a0f8d7359f", size = 28146862 },
+    { url = "https://files.pythonhosted.org/packages/6c/03/ae65e457964272051a52ad21584c1a956d55f7753d1a4b57de09ad16c6f5/icloudpd-1.27.4-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fdc249f18153bae7a2fff8e6f80f7f36e165743f2413186a548b80838a4b003", size = 63124023 },
+    { url = "https://files.pythonhosted.org/packages/22/03/82791a6bf4d7a06492aa94f6398d86cad23cf3c3266664a956dd39d5438a/icloudpd-1.27.4-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5c2a5aa980854b9c8c06d54233b048ad8b8550a579cf2c0b36926f46fda1a4da", size = 60615943 },
+    { url = "https://files.pythonhosted.org/packages/84/5c/5ba73a6b8b21b65609b58ec12992bd1145221d16f70adbd38d22902779db/icloudpd-1.27.4-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:21484450ba3aacdc357b2dc1cef2bd294041298d6a872a8be4ac53bc87846ef0", size = 65984457 },
+    { url = "https://files.pythonhosted.org/packages/0b/79/6ae47efd142a0e4d84048facc835812cf03c82b1fba1b6fbd8bb2032b6e4/icloudpd-1.27.4-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1b9fdb72dfc7fa83c5e586ef7143858d31602224fde02aca85fe2cab43eeb920", size = 34811609 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add initial syncing from iPhoto to a mounted SMB drive to support our network attached storage. This isn't yet confirmed to work because we're hitting 503 errors during the initial authentication. Some relevant tickets:

- https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/970
- https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1078
- https://github.com/icloud-photos-downloader/icloud_photos_downloader/issues/1062

The most common advice is to wait for a couple days and try again, either because or rate limiting or transient server issues.

The final backup flow will look like:

iCloud -> NAS -> [todo: B2]