### PR TITLE
Validate state of backups

### DIFF
--- a/bungalo/__tests__/plugins/test_jellyfin.py
+++ b/bungalo/__tests__/plugins/test_jellyfin.py
@@ -97,8 +97,9 @@ async def test_jellyfin_plugin_mounts_and_runs(
 
     await jellyfin.main(config)
 
-    # Two docker commands should be executed: rm -f and run
-    assert len(commands) == 2
+    # Docker readiness check plus cleanup and run commands should be executed
+    assert len(commands) == 3
+    assert commands[0][0:2] == ("docker", "info")
     run_cmd = commands[-1]
     assert run_cmd[0:2] == ("docker", "run")
     assert jellyfin.JELLYFIN_IMAGE in run_cmd

--- a/bungalo/backups/validation.py
+++ b/bungalo/backups/validation.py
@@ -1,0 +1,239 @@
+import asyncio
+import json
+import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from bungalo.app_manager import AppManager
+from bungalo.backups.remote import RCloneSync, validate_endpoints
+from bungalo.config.config import BungaloConfig, SyncPair
+from bungalo.config.paths import B2Path, FileLocation, NASPath
+from bungalo.constants import DEFAULT_RCLONE_CONFIG_FILE
+from bungalo.logger import CONSOLE, LOGGER
+from bungalo.slack import SlackClient
+
+SERVICE_NAME = "remote_validation"
+SAMPLE_COUNT = 25
+VALIDATION_INTERVAL = timedelta(hours=5)
+
+
+def _resolve_rclone_path(location: FileLocation) -> str | None:
+    match location:
+        case NASPath():
+            return f"{location.endpoint_nickname}:{location.full_path}"
+        case B2Path():
+            return f"{location.endpoint_nickname}:{location.full_path}"
+        case _:
+            return None
+
+
+def _build_object_path(base: str, entry: dict[str, Any]) -> str:
+    base_clean = base.rstrip("/")
+    relative = (entry.get("Path") or "").lstrip("/")
+    name = entry.get("Name")
+
+    if relative and name and relative == name and base_clean.endswith(name):
+        return base_clean
+    if not relative:
+        return base_clean
+    return f"{base_clean}/{relative}"
+
+
+async def _list_remote_files(
+    remote_path: str, config_path: Path
+) -> list[dict[str, Any]]:
+    process = await asyncio.create_subprocess_exec(
+        "rclone",
+        "lsjson",
+        "--recursive",
+        "--files-only",
+        "--fast-list",
+        "--config",
+        str(config_path),
+        remote_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode:
+        error_output = stderr.decode() or stdout.decode()
+        raise RuntimeError(
+            f"rclone lsjson failed for {remote_path}: {error_output.strip()}"
+        )
+
+    try:
+        entries = json.loads(stdout.decode() or "[]")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Failed to parse rclone lsjson output: {exc}") from exc
+
+    if not isinstance(entries, list):
+        raise RuntimeError("Unexpected lsjson output format")
+    return entries
+
+
+async def _validate_remote_file(object_path: str, config_path: Path) -> int:
+    process = await asyncio.create_subprocess_exec(
+        "rclone",
+        "cat",
+        "--count",
+        "1",
+        "--config",
+        str(config_path),
+        object_path,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await process.communicate()
+    if process.returncode:
+        error_output = stderr.decode() or stdout.decode()
+        raise RuntimeError(
+            f"rclone cat failed for {object_path}: {error_output.strip()}"
+        )
+    return len(stdout)
+
+
+async def _validate_pair(
+    pair: SyncPair,
+    *,
+    config_path: Path,
+) -> tuple[int, list[str]]:
+    label = str(pair.dst)
+    remote_path = _resolve_rclone_path(pair.dst)
+    if remote_path is None:
+        LOGGER.debug("Skipping validation for unsupported path type: %s", label)
+        return 0, []
+
+    files = await _list_remote_files(remote_path, config_path)
+    if not files:
+        return 0, [f"{label}: remote path contains no files"]
+
+    sample_size = min(SAMPLE_COUNT, len(files))
+    selected = random.sample(files, sample_size)
+
+    errors: list[str] = []
+    for entry in selected:
+        object_path = _build_object_path(remote_path, entry)
+        try:
+            bytes_read = await _validate_remote_file(object_path, config_path)
+        except Exception as exc:
+            errors.append(
+                f"{label}: failed to decrypt {entry.get('Path') or entry.get('Name')}: {exc}"
+            )
+            continue
+
+        if bytes_read <= 0:
+            errors.append(
+                f"{label}: decrypted zero bytes from {entry.get('Path') or entry.get('Name')}"
+            )
+
+    return sample_size, errors
+
+
+async def main(config: BungaloConfig) -> None:
+    endpoints_by_nickname = validate_endpoints(config.endpoints.get_all())
+    sync_pairs = [SyncPair.model_validate(raw_pair) for raw_pair in config.backups.sync]
+
+    slack_client = SlackClient(
+        app_token=config.slack.app_token,
+        bot_token=config.slack.bot_token,
+        channel_id=config.slack.channel,
+    )
+
+    rclone_sync = RCloneSync(
+        config_path=Path(DEFAULT_RCLONE_CONFIG_FILE).expanduser(),
+        endpoints=endpoints_by_nickname,
+        pairs=sync_pairs,
+        slack_client=slack_client,
+    )
+    await rclone_sync.write_config()
+
+    manager = AppManager.get()
+    interval_seconds = VALIDATION_INTERVAL.total_seconds()
+
+    await manager.update_service(
+        SERVICE_NAME,
+        state="idle",
+        detail="Waiting to start remote validation",
+        next_run_at=datetime.now(timezone.utc),
+    )
+
+    while True:
+        if not sync_pairs:
+            await manager.update_service(
+                SERVICE_NAME,
+                state="idle",
+                detail="No remote backup pairs configured",
+                next_run_at=datetime.now(timezone.utc) + VALIDATION_INTERVAL,
+                last_run_at=datetime.now(timezone.utc),
+            )
+            await asyncio.sleep(interval_seconds)
+            continue
+
+        start_time = datetime.now(timezone.utc)
+        await manager.update_service(
+            SERVICE_NAME,
+            state="running",
+            detail="Starting remote backup validation",
+            last_run_at=start_time,
+        )
+
+        total_checked = 0
+        all_errors: list[str] = []
+
+        for pair in sync_pairs:
+            await manager.update_service(
+                SERVICE_NAME,
+                state="running",
+                detail=f"Validating {pair.dst}",
+            )
+            try:
+                checked, errors = await _validate_pair(
+                    pair,
+                    config_path=rclone_sync.config_path,
+                )
+                total_checked += checked
+                all_errors.extend(errors)
+            except Exception as exc:
+                error_message = f"{pair.dst}: validation failed: {exc}"
+                LOGGER.error(error_message)
+                all_errors.append(error_message)
+
+        next_run_at = datetime.now(timezone.utc) + VALIDATION_INTERVAL
+
+        if all_errors:
+            detail = f"Validation failed: {len(all_errors)} issues detected"
+            await manager.update_service(
+                SERVICE_NAME,
+                state="error",
+                detail=detail,
+                next_run_at=next_run_at,
+            )
+
+            summary_lines = [
+                "🚨 Remote backup validation failed.",
+                f"Checked {total_checked} files across {len(sync_pairs)} backups.",
+                "Issues:",
+            ]
+            for line in all_errors[:10]:
+                summary_lines.append(f"• {line}")
+            if len(all_errors) > 10:
+                summary_lines.append(f"...and {len(all_errors) - 10} more.")
+
+            message = "\n".join(summary_lines)
+            await slack_client.create_status(message)
+            CONSOLE.print(message)
+        else:
+            detail = f"Validated {total_checked} files across {len(sync_pairs)} backups"
+            await manager.update_service(
+                SERVICE_NAME,
+                state="idle",
+                detail=detail,
+                next_run_at=next_run_at,
+            )
+            LOGGER.info(detail)
+
+        await asyncio.sleep(interval_seconds)
+
+
+__all__ = ["main"]

--- a/bungalo/cli.py
+++ b/bungalo/cli.py
@@ -8,6 +8,7 @@ from click import group
 from bungalo.app_manager import AppManager
 from bungalo.backups.iphoto import main as iphoto_main
 from bungalo.backups.remote import main as remote_main
+from bungalo.backups.validation import main as remote_validation_main
 from bungalo.config import BungaloConfig
 from bungalo.constants import DEFAULT_CONFIG_FILE
 from bungalo.dashboard import start_dashboard_services
@@ -61,6 +62,7 @@ async def run_all():
         battery_main(config),
         iphoto_main(config),
         remote_main(config),
+        remote_validation_main(config),
     ]
     if config.media_server and config.media_server.plugin == "jellyfin":
         tasks.append(jellyfin_main(config))

--- a/bungalo/system_metrics.py
+++ b/bungalo/system_metrics.py
@@ -1,0 +1,102 @@
+import asyncio
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import psutil
+
+PROCESS_SAMPLE_LIMIT = 5
+PROCESS_SAMPLE_DELAY = 0.1
+
+
+def _collect_top_processes() -> list[dict[str, Any]]:
+    processes = []
+    primed_processes: list[psutil.Process] = []
+
+    for proc in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            proc.cpu_percent(interval=None)
+            primed_processes.append(proc)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    time.sleep(PROCESS_SAMPLE_DELAY)
+
+    for proc in primed_processes:
+        try:
+            cpu_percent = proc.cpu_percent(interval=None)
+            memory_percent = proc.memory_percent()
+            cmdline = proc.info.get("cmdline") or []
+            command = " ".join(cmdline) if cmdline else proc.info.get("name") or ""
+            processes.append(
+                {
+                    "pid": proc.pid,
+                    "name": proc.info.get("name") or command or f"pid {proc.pid}",
+                    "command": command,
+                    "cpu_percent": cpu_percent,
+                    "memory_percent": memory_percent,
+                }
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            continue
+
+    processes.sort(key=lambda entry: entry["cpu_percent"], reverse=True)
+    return processes[:PROCESS_SAMPLE_LIMIT]
+
+
+def _collect_metrics_sync() -> dict[str, Any]:
+    cpu_per_core = psutil.cpu_percent(interval=0.1, percpu=True)
+    load_average = None
+    try:
+        load_values = getattr(psutil, "getloadavg", os.getloadavg)()
+        load_average = {
+            "1m": load_values[0],
+            "5m": load_values[1],
+            "15m": load_values[2],
+        }
+    except (AttributeError, OSError):
+        load_average = None
+
+    memory = psutil.virtual_memory()
+    swap = psutil.swap_memory()
+    processes = _collect_top_processes()
+
+    return {
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "cpu": {
+            "cores": [
+                {
+                    "index": idx,
+                    "percent": value,
+                }
+                for idx, value in enumerate(cpu_per_core)
+            ],
+            "average_percent": sum(cpu_per_core) / len(cpu_per_core)
+            if cpu_per_core
+            else 0.0,
+            "load_average": load_average,
+        },
+        "memory": {
+            "total": memory.total,
+            "available": memory.available,
+            "used": memory.used,
+            "free": memory.free,
+            "percent": memory.percent,
+        },
+        "swap": {
+            "total": swap.total,
+            "used": swap.used,
+            "free": swap.free,
+            "percent": swap.percent,
+        },
+        "processes": processes,
+    }
+
+
+async def collect_system_metrics() -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _collect_metrics_sync)
+
+
+__all__ = ["collect_system_metrics"]

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -7,6 +7,52 @@ export interface ServiceStatus {
   last_run_at?: string | null;
 }
 
+export interface CpuCoreMetric {
+  index: number;
+  percent: number;
+}
+
+export interface LoadAverage {
+  "1m": number;
+  "5m": number;
+  "15m": number;
+}
+
+export interface ProcessMetric {
+  pid: number;
+  name: string;
+  command: string;
+  cpu_percent: number;
+  memory_percent: number;
+}
+
+export interface SystemMetrics {
+  collected_at: string;
+  cpu: {
+    cores: CpuCoreMetric[];
+    average_percent: number;
+    load_average: LoadAverage | null;
+  };
+  memory: {
+    total: number;
+    available: number;
+    used: number;
+    free: number;
+    percent: number;
+  };
+  swap: {
+    total: number;
+    used: number;
+    free: number;
+    percent: number;
+  };
+  processes: ProcessMetric[];
+}
+
+export interface SystemMetricsError {
+  error: string;
+}
+
 export interface TaskState {
   id: string;
   title: string;
@@ -24,6 +70,7 @@ export interface AppState {
   started_at: string;
   services: ServiceStatus[];
   tasks: TaskState[];
+  system?: SystemMetrics | SystemMetricsError;
 }
 
 function resolveApiBase(): string {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "nut2>=2.1.1",
     "pydantic-settings>=2.8.1",
     "pydantic>=2.11.3",
+    "psutil>=5.9.0",
     "rich>=14.0.0",
     "slack-sdk>=3.35.0",
     "uvicorn[standard]>=0.30.0",

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,7 @@ dependencies = [
     { name = "httpx" },
     { name = "icloudpd" },
     { name = "nut2" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -172,6 +173,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "icloudpd", git = "https://github.com/piercefreeman/icloud_photos_downloader" },
     { name = "nut2", specifier = ">=2.1.1" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "pydantic-settings", specifier = ">=2.8.1" },
     { name = "rich", specifier = ">=14.0.0" },
@@ -838,6 +840,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/66/2e90547d6b60180fb29e23dc87bd8c116517d4255240ec6d3f7dc23d1926/propcache-0.3.1-cp313-cp313t-win32.whl", hash = "sha256:359e81a949a7619802eb601d66d37072b79b79c2505e6d3fd8b945538411400d", size = 42573, upload-time = "2025-03-26T03:05:39.193Z" },
     { url = "https://files.pythonhosted.org/packages/cb/8f/50ad8599399d1861b4d2b6b45271f0ef6af1b09b0a2386a46dbaf19c9535/propcache-0.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e7fb9a84c9abbf2b2683fa3e7b0d7da4d8ecf139a1c635732a8bda29c5214b0e", size = 46757, upload-time = "2025-03-26T03:05:40.811Z" },
     { url = "https://files.pythonhosted.org/packages/b8/d3/c3cb8f1d6ae3b37f83e1de806713a9b3642c5895f0215a62e1a4bd6e5e34/propcache-0.3.1-py3-none-any.whl", hash = "sha256:9a8ecf38de50a7f518c21568c80f985e776397b902f1ce0b01f799aba1608b40", size = 12376, upload-time = "2025-03-26T03:06:10.5Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ec/7b8e6b9b1d22708138630ef34c53ab2b61032c04f16adfdbb96791c8c70c/psutil-7.1.2.tar.gz", hash = "sha256:aa225cdde1335ff9684708ee8c72650f6598d5ed2114b9a7c5802030b1785018", size = 487424, upload-time = "2025-10-25T10:46:34.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/d9/b56cc9f883140ac10021a8c9b0f4e16eed1ba675c22513cdcbce3ba64014/psutil-7.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0cc5c6889b9871f231ed5455a9a02149e388fffcb30b607fb7a8896a6d95f22e", size = 238575, upload-time = "2025-10-25T10:46:38.728Z" },
+    { url = "https://files.pythonhosted.org/packages/36/eb/28d22de383888deb252c818622196e709da98816e296ef95afda33f1c0a2/psutil-7.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8e9e77a977208d84aa363a4a12e0f72189d58bbf4e46b49aae29a2c6e93ef206", size = 239297, upload-time = "2025-10-25T10:46:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/220039e2f28cc129626e54d63892ab05c0d56a29818bfe7268dcb5008932/psutil-7.1.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d9623a5e4164d2220ecceb071f4b333b3c78866141e8887c072129185f41278", size = 280420, upload-time = "2025-10-25T10:46:44.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/286f0e1c167445b2ef4a6cbdfc8c59fdb45a5a493788950cf8467201dc73/psutil-7.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:364b1c10fe4ed59c89ec49e5f1a70da353b27986fa8233b4b999df4742a5ee2f", size = 283049, upload-time = "2025-10-25T10:46:47.095Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cc/7eb93260794a42e39b976f3a4dde89725800b9f573b014fac142002a5c98/psutil-7.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:f101ef84de7e05d41310e3ccbdd65a6dd1d9eed85e8aaf0758405d022308e204", size = 248713, upload-time = "2025-10-25T10:46:49.573Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1a/0681a92b53366e01f0a099f5237d0c8a2f79d322ac589cccde5e30c8a4e2/psutil-7.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:20c00824048a95de67f00afedc7b08b282aa08638585b0206a9fb51f28f1a165", size = 244644, upload-time = "2025-10-25T10:46:51.924Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/f1c5c746b4ed5320952acd3002d3962fe36f30524c00ea79fdf954cc6779/psutil-7.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:e09cfe92aa8e22b1ec5e2d394820cf86c5dff6367ac3242366485dfa874d43bc", size = 238640, upload-time = "2025-10-25T10:46:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ee/fd26216a735395cc25c3899634e34aeb41fb1f3dbb44acc67d9e594be562/psutil-7.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fa6342cf859c48b19df3e4aa170e4cfb64aadc50b11e06bb569c6c777b089c9e", size = 239303, upload-time = "2025-10-25T10:46:56.932Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/cd/7d96eaec4ef7742b845a9ce2759a2769ecce4ab7a99133da24abacbc9e41/psutil-7.1.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:625977443498ee7d6c1e63e93bacca893fd759a66c5f635d05e05811d23fb5ee", size = 281717, upload-time = "2025-10-25T10:46:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/1a/7f0b84bdb067d35fe7fade5fff888408688caf989806ce2d6dae08c72dd5/psutil-7.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a24bcd7b7f2918d934af0fb91859f621b873d6aa81267575e3655cd387572a7", size = 284575, upload-time = "2025-10-25T10:47:00.944Z" },
+    { url = "https://files.pythonhosted.org/packages/de/05/7820ef8f7b275268917e0c750eada5834581206d9024ca88edce93c4b762/psutil-7.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:329f05610da6380982e6078b9d0881d9ab1e9a7eb7c02d833bfb7340aa634e31", size = 249491, upload-time = "2025-10-25T10:47:03.174Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9a/58de399c7cb58489f08498459ff096cd76b3f1ddc4f224ec2c5ef729c7d0/psutil-7.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:7b04c29e3c0c888e83ed4762b70f31e65c42673ea956cefa8ced0e31e185f582", size = 244880, upload-time = "2025-10-25T10:47:05.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/89/b9f8d47ddbc52d7301fc868e8224e5f44ed3c7f55e6d0f54ecaf5dd9ff5e/psutil-7.1.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c9ba5c19f2d46203ee8c152c7b01df6eec87d883cfd8ee1af2ef2727f6b0f814", size = 237244, upload-time = "2025-10-25T10:47:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/7a/8628c2f6b240680a67d73d8742bb9ff39b1820a693740e43096d5dcb01e5/psutil-7.1.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:2a486030d2fe81bec023f703d3d155f4823a10a47c36784c84f1cc7f8d39bedb", size = 238101, upload-time = "2025-10-25T10:47:09.523Z" },
+    { url = "https://files.pythonhosted.org/packages/30/28/5e27f4d5a0e347f8e3cc16cd7d35533dbce086c95807f1f0e9cd77e26c10/psutil-7.1.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3efd8fc791492e7808a51cb2b94889db7578bfaea22df931424f874468e389e3", size = 258675, upload-time = "2025-10-25T10:47:11.082Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/5c/79cf60c9acf36d087f0db0f82066fca4a780e97e5b3a2e4c38209c03d170/psutil-7.1.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e2aeb9b64f481b8eabfc633bd39e0016d4d8bbcd590d984af764d80bf0851b8a", size = 260203, upload-time = "2025-10-25T10:47:13.226Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/03/0a464404c51685dcb9329fdd660b1721e076ccd7b3d97dee066bcc9ffb15/psutil-7.1.2-cp37-abi3-win_amd64.whl", hash = "sha256:8e17852114c4e7996fe9da4745c2bdef001ebbf2f260dec406290e66628bdb91", size = 246714, upload-time = "2025-10-25T10:47:15.093Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/32/97ca2090f2f1b45b01b6aa7ae161cfe50671de097311975ca6eea3e7aabc/psutil-7.1.2-cp37-abi3-win_arm64.whl", hash = "sha256:3e988455e61c240cc879cb62a008c2699231bf3e3d061d7fce4234463fd2abb4", size = 243742, upload-time = "2025-10-25T10:47:17.302Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a new service that does a bit of automatic confirmation that our backups are "valid". For the moment we define a valid backup as able to be decrypted using our encryption keys and having a nonzero file size. Our two main concerns with backups are:

1. There will be some rclone failures that indicate we made a successful backup, but some files actually got missed and we lose them during a restore.
2. Somehow our keys get outdated and we become unable to read from the remote when we actually have to restore.

This case addresses (2) more than 1. We assume that rclone's robustness will mitigate this possibility - but we could also implement our own sha or timestamp checks if we want to take that a step further in the future.

We also add the load status of the server to the homepage:

<img width="1871" height="1059" alt="Screenshot 2025-10-26 at 11 18 52 AM" src="https://github.com/user-attachments/assets/38a64fa9-342e-4029-9ed2-69823bd0f9a8" />
