### PR TITLE
Add initial sunrise automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ make test -- -k test_fully_parameterized_config
      --network host \
      --device=/dev/bus/usb \
      -v ~/.bungalo:/root/.bungalo \
+     -v ~/.bungalo/docker:/var/lib/docker \
      -v /dev/bus/usb:/dev/bus/usb \
      --cap-add=SYS_ADMIN \
      --device /dev/fuse \
@@ -145,6 +146,7 @@ make test -- -k test_fully_parameterized_config
    - `--network host`: Allows direct access to host network for SSH operations
    - `-v /var/run/docker.sock:/var/run/docker.sock`: **No longer needed** - we use Docker-in-Docker for Jellyfin instead of the host daemon
    - `-v ~/.bungalo:/root/.bungalo`: Mounts your config directory
+   - `-v ~/.bungalo/docker:/var/lib/docker`: Persists the inner Docker daemon's layer cache so container images (Jellyfin, Home Assistant) survive restarts
    - `-v /dev/bus/usb:/dev/bus/usb`: Mounts USB devices
    - `--cap-add=SYS_ADMIN` and `--device /dev/fuse`: Required for FUSE mounts (NAS shares)
 
@@ -156,6 +158,7 @@ make test -- -k test_fully_parameterized_config
         --network host \
         --device=/dev/bus/usb \
         -v ~/.bungalo:/root/.bungalo \
+        -v ~/.bungalo/docker:/var/lib/docker \
         -v /dev/bus/usb:/dev/bus/usb \
         --cap-add=SYS_ADMIN \
         --device /dev/fuse \

--- a/README.md
+++ b/README.md
@@ -96,6 +96,27 @@ Mounts are published to the container as read-only volumes so Jellyfin can index
 
 **Architecture:** Jellyfin runs via Docker-in-Docker (DinD). When the Bungalo container starts, it launches an inner Docker daemon that Jellyfin uses. This allows Jellyfin to access the NAS shares that Bungalo mounts (via SMB/FUSE) inside the container, solving the sibling-container volume mounting problem. The inner Docker daemon uses the `vfs` storage driver for simplicity and runs in privileged mode.
 
+### Home Assistant
+
+Enable Home Assistant by setting `enabled = true` in your config:
+
+```toml
+[home_assistant]
+  enabled = true
+```
+
+Bungalo launches two containers via Docker-in-Docker: the Home Assistant core container and a [Matter Server](https://github.com/matter-js/python-matter-server) sidecar for Matter device support. Both run on host network.
+
+On first launch, Bungalo seeds a set of starter configuration files into `~/.bungalo/home_assistant/config/`, including a sunrise wake-up automation and a matching manual script. These are only written if the files don't already exist — your customizations are never overwritten.
+
+The bundled automations reference a placeholder `light.bedroom` entity. You'll need to update them to match your actual devices, either by editing the YAML files directly in `~/.bungalo/home_assistant/config/` or through the Home Assistant UI under **Settings → Automations & Scenes**. The same applies for any new integrations (Hue, Zigbee, etc.) — configure those through the HA UI at **Settings → Devices & Services**.
+
+A standalone command is also available:
+
+```bash
+bungalo home-assistant
+```
+
 ## Future Work
 
 - Unifi devices don't support wake-on-lan, so once they're shutdown there's no way to remotely start them back up. We'll have to combine it with a remotely controllable Power Distribution Unit if we want to add the restart behavior.

--- a/bungalo/__tests__/plugins/test_jellyfin.py
+++ b/bungalo/__tests__/plugins/test_jellyfin.py
@@ -97,9 +97,11 @@ async def test_jellyfin_plugin_mounts_and_runs(
 
     await jellyfin.main(config)
 
-    # Docker readiness check plus cleanup and run commands should be executed
-    assert len(commands) == 3
+    # Docker readiness check, pull, cleanup, and run commands should be executed
+    assert len(commands) == 4
     assert commands[0][0:2] == ("docker", "info")
+    assert commands[1][0:2] == ("docker", "pull")
+    assert jellyfin.JELLYFIN_IMAGE in commands[1]
     run_cmd = commands[-1]
     assert run_cmd[0:2] == ("docker", "run")
     assert jellyfin.JELLYFIN_IMAGE in run_cmd

--- a/bungalo/app_manager.py
+++ b/bungalo/app_manager.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, ClassVar, Dict, Optional
 
 from bungalo.logger import LOGGER
+from bungalo.port_check import check_ports
 from bungalo.system_metrics import collect_system_metrics
 
 
@@ -80,6 +81,10 @@ class AppTask:
 class AppManager:
     _instance: ClassVar[Optional["AppManager"]] = None
 
+    # Map of label → port for services that expose HTTP ports.
+    # Checked on each /api/state request to report reachability.
+    _port_checks: ClassVar[Dict[str, int]] = {}
+
     def __init__(self):
         self._lock = asyncio.Lock()
         self._services: Dict[str, ServiceStatus] = {}
@@ -89,6 +94,11 @@ class AppManager:
         self.dashboard_base_url = os.environ.get(
             "BUNGALO_DASHBOARD_URL", "http://localhost:80"
         )
+
+    @classmethod
+    def register_port_check(cls, name: str, port: int) -> None:
+        """Register a service port to be polled for reachability."""
+        cls._port_checks[name] = port
 
     @classmethod
     def get(cls) -> "AppManager":
@@ -261,6 +271,9 @@ class AppManager:
         except Exception as exc:  # pragma: no cover - defensive fallback
             LOGGER.error("Failed to collect system metrics: %s", exc)
             state["system"] = {"error": str(exc)}
+
+        if self._port_checks:
+            state["port_status"] = await check_ports(self._port_checks)
 
         return state
 

--- a/bungalo/cli.py
+++ b/bungalo/cli.py
@@ -67,7 +67,7 @@ async def run_all():
     ]
     if config.media_server and config.media_server.plugin == "jellyfin":
         tasks.append(jellyfin_main(config))
-    if config.home_assistant:
+    if config.home_assistant.enabled:
         tasks.append(home_assistant_main(config))
     await asyncio.gather(*tasks)
 

--- a/bungalo/cli.py
+++ b/bungalo/cli.py
@@ -14,6 +14,7 @@ from bungalo.constants import DEFAULT_CONFIG_FILE
 from bungalo.dashboard import start_dashboard_services
 from bungalo.io import async_to_sync
 from bungalo.nut.cli import main as battery_main
+from bungalo.plugins.home_assistant import main as home_assistant_main
 from bungalo.plugins.jellyfin import main as jellyfin_main
 from bungalo.ssh import main as ssh_main
 
@@ -66,6 +67,8 @@ async def run_all():
     ]
     if config.media_server and config.media_server.plugin == "jellyfin":
         tasks.append(jellyfin_main(config))
+    if config.home_assistant:
+        tasks.append(home_assistant_main(config))
     await asyncio.gather(*tasks)
 
 
@@ -106,6 +109,14 @@ async def jellyfin():
     """Launch the Jellyfin media server plugin."""
     config = get_config()
     await jellyfin_main(config)
+
+
+@cli.command()
+@async_to_sync
+async def home_assistant():
+    """Launch the Home Assistant container."""
+    config = get_config()
+    await home_assistant_main(config)
 
 
 def get_config():

--- a/bungalo/config/config.py
+++ b/bungalo/config/config.py
@@ -91,6 +91,10 @@ class MediaServerConfig(BaseSettings):
         return self
 
 
+class HomeAssistantConfig(BaseSettings):
+    port: int = 8123
+
+
 class EndpointConfig(BaseSettings):
     b2: list[B2Endpoint] = []
     nas: list[NASEndpoint] = []
@@ -144,6 +148,9 @@ class BungaloConfig(BaseSettings):
 
     # Media servers (e.g., Jellyfin)
     media_server: MediaServerConfig | None = None
+
+    # Home automation
+    home_assistant: HomeAssistantConfig | None = None
 
     # Validate that all of the remote files that were validated to NAS files or
     # B2 accounts match the nicknames that we have specified

--- a/bungalo/config/config.py
+++ b/bungalo/config/config.py
@@ -92,6 +92,7 @@ class MediaServerConfig(BaseSettings):
 
 
 class HomeAssistantConfig(BaseSettings):
+    enabled: bool = False
     port: int = 8123
 
 
@@ -150,7 +151,7 @@ class BungaloConfig(BaseSettings):
     media_server: MediaServerConfig | None = None
 
     # Home automation
-    home_assistant: HomeAssistantConfig | None = None
+    home_assistant: HomeAssistantConfig = Field(default_factory=HomeAssistantConfig)
 
     # Validate that all of the remote files that were validated to NAS files or
     # B2 accounts match the nicknames that we have specified

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -10,7 +10,9 @@ from bungalo.logger import CONSOLE
 from bungalo.slack import SlackClient
 
 HOME_ASSISTANT_IMAGE = "ghcr.io/home-assistant/home-assistant:stable"
+MATTER_SERVER_IMAGE = "ghcr.io/home-assistant-libs/python-matter-server:stable"
 CONTAINER_NAME = "bungalo-home-assistant"
+MATTER_CONTAINER_NAME = "bungalo-matter-server"
 DOCKER_READY_TIMEOUT = 60  # seconds
 
 
@@ -21,17 +23,19 @@ def _get_root() -> Path:
     ).expanduser()
 
 
-def _ensure_directories() -> Path:
+def _ensure_directories() -> tuple[Path, Path]:
     """
     Ensure the default directory structure required for Home Assistant exists.
 
     Returns:
-        The config directory path.
+        Tuple of (config_dir, matter_data_dir).
     """
     root = _get_root()
     config_dir = root / "config"
+    matter_data_dir = root / "matter"
     config_dir.mkdir(parents=True, exist_ok=True)
-    return config_dir
+    matter_data_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir, matter_data_dir
 
 
 def _seed_default_config(config_dir: Path) -> None:
@@ -92,24 +96,73 @@ async def _ensure_docker_ready() -> None:
     )
 
 
-async def _remove_existing_container() -> None:
-    """Best-effort removal of an existing Home Assistant container with our managed name."""
+async def _remove_existing_container(name: str) -> None:
+    """Best-effort removal of an existing container by name."""
     process = await asyncio.create_subprocess_exec(
         "docker",
         "rm",
         "-f",
-        CONTAINER_NAME,
+        name,
         stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.DEVNULL,
     )
     await process.wait()
 
 
+async def _pull_image(image: str, service_name: str, app_manager: AppManager) -> None:
+    """Pull a Docker image, updating service status."""
+    CONSOLE.print(f"Pulling image '{image}'")
+    await app_manager.update_service(
+        service_name,
+        state="pulling",
+        detail=f"Pulling image {image}",
+    )
+    pull_process = await asyncio.create_subprocess_exec(
+        "docker",
+        "pull",
+        image,
+    )
+    pull_rc = await pull_process.wait()
+    if pull_rc:
+        await app_manager.update_service(
+            service_name,
+            state="error",
+            detail=f"Failed to pull image {image} (exit code {pull_rc})",
+        )
+        raise RuntimeError(f"Failed to pull {image} (exit code {pull_rc})")
+
+
+async def _start_matter_server(matter_data_dir: Path) -> asyncio.subprocess.Process:
+    """Launch the Matter Server container and return the process handle."""
+    timezone = os.environ.get("TZ", "UTC")
+
+    matter_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        MATTER_CONTAINER_NAME,
+        "--network",
+        "host",
+        "--privileged",
+        "-e",
+        f"TZ={timezone}",
+        "-v",
+        f"{matter_data_dir}:/data",
+        MATTER_SERVER_IMAGE,
+    ]
+
+    CONSOLE.print(f"Starting Matter Server container '{MATTER_CONTAINER_NAME}'")
+    await _remove_existing_container(MATTER_CONTAINER_NAME)
+    return await asyncio.create_subprocess_exec(*matter_cmd)
+
+
 async def main(config: BungaloConfig) -> None:
     """
-    Launch the Home Assistant container via Docker-in-Docker.
+    Launch the Home Assistant and Matter Server containers via Docker-in-Docker.
 
-    Home Assistant runs on host network with a persistent config volume.
+    Both containers run on host network. The Matter Server listens on port 5580
+    and Home Assistant connects to it for Matter device support.
     """
     app_manager = AppManager.get()
     service_name = "home_assistant"
@@ -127,10 +180,17 @@ async def main(config: BungaloConfig) -> None:
 
     await _ensure_docker_ready()
 
-    config_dir = _ensure_directories()
+    config_dir, matter_data_dir = _ensure_directories()
     _seed_default_config(config_dir)
 
     timezone = os.environ.get("TZ", "UTC")
+
+    # Pull both images
+    await _pull_image(MATTER_SERVER_IMAGE, service_name, app_manager)
+    await _pull_image(HOME_ASSISTANT_IMAGE, service_name, app_manager)
+
+    # Start Matter Server first so it's ready when HA boots
+    matter_process = await _start_matter_server(matter_data_dir)
 
     docker_cmd = [
         "docker",
@@ -148,34 +208,14 @@ async def main(config: BungaloConfig) -> None:
         HOME_ASSISTANT_IMAGE,
     ]
 
-    CONSOLE.print(f"Pulling Home Assistant image '{HOME_ASSISTANT_IMAGE}'")
-    await app_manager.update_service(
-        service_name,
-        state="pulling",
-        detail=f"Pulling image {HOME_ASSISTANT_IMAGE}",
-    )
-    pull_process = await asyncio.create_subprocess_exec(
-        "docker",
-        "pull",
-        HOME_ASSISTANT_IMAGE,
-    )
-    pull_rc = await pull_process.wait()
-    if pull_rc:
-        await app_manager.update_service(
-            service_name,
-            state="error",
-            detail=f"Failed to pull image {HOME_ASSISTANT_IMAGE} (exit code {pull_rc})",
-        )
-        raise RuntimeError(f"Failed to pull Home Assistant image (exit code {pull_rc})")
-
     CONSOLE.print(f"Starting Home Assistant container '{CONTAINER_NAME}'")
-    await _remove_existing_container()
+    await _remove_existing_container(CONTAINER_NAME)
     await app_manager.update_service(
         service_name,
         state="running",
         detail="Home Assistant running",
     )
-    process = await asyncio.create_subprocess_exec(*docker_cmd)
+    ha_process = await asyncio.create_subprocess_exec(*docker_cmd)
 
     ha_port = ha_config.port
     ha_host = os.environ.get("HOME_ASSISTANT_EXTERNAL_HOST") or (
@@ -184,17 +224,34 @@ async def main(config: BungaloConfig) -> None:
         else f"http://127.0.0.1:{ha_port}"
     )
     await slack_client.create_status(f"Home Assistant is now running → {ha_host}")
-    returncode = await process.wait()
+
+    # Wait for either container to exit
+    done, _ = await asyncio.wait(
+        [
+            asyncio.create_task(ha_process.wait()),
+            asyncio.create_task(matter_process.wait()),
+        ],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    # If HA exited, clean up Matter Server too
+    if ha_process.returncode is not None:
+        await _remove_existing_container(MATTER_CONTAINER_NAME)
+        returncode = ha_process.returncode
+    else:
+        # Matter Server exited unexpectedly — report but keep HA running
+        await _remove_existing_container(CONTAINER_NAME)
+        returncode = matter_process.returncode
 
     if returncode:
         await app_manager.update_service(
             service_name,
             state="error",
-            detail=f"Home Assistant container exited with code {returncode}",
+            detail=f"Home Assistant exited with code {returncode}",
         )
-        raise RuntimeError(f"Home Assistant container exited with code {returncode}")
+        raise RuntimeError(f"Home Assistant exited with code {returncode}")
     await app_manager.update_service(
         service_name,
         state="completed",
-        detail="Home Assistant container stopped",
+        detail="Home Assistant stopped",
     )

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -10,7 +10,7 @@ from bungalo.logger import CONSOLE
 from bungalo.slack import SlackClient
 
 HOME_ASSISTANT_IMAGE = "ghcr.io/home-assistant/home-assistant:stable"
-MATTER_SERVER_IMAGE = "ghcr.io/home-assistant-libs/python-matter-server:stable"
+MATTER_SERVER_IMAGE = "ghcr.io/matter-js/python-matter-server:stable"
 CONTAINER_NAME = "bungalo-home-assistant"
 MATTER_CONTAINER_NAME = "bungalo-matter-server"
 DOCKER_READY_TIMEOUT = 60  # seconds

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -113,13 +113,15 @@ async def main(config: BungaloConfig) -> None:
     """
     app_manager = AppManager.get()
     service_name = "home_assistant"
+
+    ha_config = config.home_assistant
+    AppManager.register_port_check("home_assistant", ha_config.port)
+
     slack_client = SlackClient(
         app_token=config.slack.app_token,
         bot_token=config.slack.bot_token,
         channel_id=config.slack.channel,
     )
-
-    ha_config = config.home_assistant
     if not ha_config.enabled:
         raise ValueError("Home Assistant is not enabled in config")
 

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -120,8 +120,8 @@ async def main(config: BungaloConfig) -> None:
     )
 
     ha_config = config.home_assistant
-    if not ha_config:
-        raise ValueError("Home Assistant config not defined")
+    if not ha_config.enabled:
+        raise ValueError("Home Assistant is not enabled in config")
 
     await _ensure_docker_ready()
 

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -1,0 +1,188 @@
+import asyncio
+import os
+import shutil
+from importlib import resources
+from pathlib import Path
+
+from bungalo.app_manager import AppManager
+from bungalo.config import BungaloConfig
+from bungalo.logger import CONSOLE
+from bungalo.slack import SlackClient
+
+HOME_ASSISTANT_IMAGE = "ghcr.io/home-assistant/home-assistant:stable"
+CONTAINER_NAME = "bungalo-home-assistant"
+DOCKER_READY_TIMEOUT = 60  # seconds
+
+
+def _get_root() -> Path:
+    """Return the root directory for Home Assistant runtime data."""
+    return Path(
+        os.environ.get("BUNGALO_HOME_ASSISTANT_ROOT", "~/.bungalo/home_assistant")
+    ).expanduser()
+
+
+def _ensure_directories() -> Path:
+    """
+    Ensure the default directory structure required for Home Assistant exists.
+
+    Returns:
+        The config directory path.
+    """
+    root = _get_root()
+    config_dir = root / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir
+
+
+def _seed_default_config(config_dir: Path) -> None:
+    """
+    Copy seed configuration files into the Home Assistant config directory.
+
+    Only writes files that do not already exist, so user customizations
+    are never overwritten.
+    """
+    seed_package = resources.files("bungalo.plugins.home_assistant_seed")
+
+    for item in seed_package.iterdir():
+        if not item.name.endswith(".yaml"):
+            continue
+
+        dest = config_dir / item.name
+        if dest.exists():
+            CONSOLE.print(
+                f"Skipping seed file '{item.name}' — already exists at '{dest}'"
+            )
+            continue
+
+        with resources.as_file(item) as src_path:
+            shutil.copy2(src_path, dest)
+        CONSOLE.print(f"Seeded default config '{item.name}' → '{dest}'")
+
+
+async def _ensure_docker_ready() -> None:
+    """
+    Ensure the inner Docker daemon is ready to accept commands.
+
+    The entrypoint script should have already started dockerd, but this provides
+    an additional safety check in case home_assistant is run independently.
+    """
+    CONSOLE.print("Verifying Docker daemon is ready...")
+
+    for attempt in range(DOCKER_READY_TIMEOUT):
+        process = await asyncio.create_subprocess_exec(
+            "docker",
+            "info",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        returncode = await process.wait()
+
+        if returncode == 0:
+            CONSOLE.print("Docker daemon is ready!")
+            return
+
+        if attempt == 0:
+            CONSOLE.print("Docker daemon not yet ready, waiting...")
+
+        await asyncio.sleep(1)
+
+    raise RuntimeError(
+        f"Docker daemon not ready after {DOCKER_READY_TIMEOUT}s. "
+        "Ensure the container is running with --privileged and dockerd is started."
+    )
+
+
+async def _remove_existing_container() -> None:
+    """Best-effort removal of an existing Home Assistant container with our managed name."""
+    process = await asyncio.create_subprocess_exec(
+        "docker",
+        "rm",
+        "-f",
+        CONTAINER_NAME,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    await process.wait()
+
+
+async def main(config: BungaloConfig) -> None:
+    """
+    Launch the Home Assistant container via Docker-in-Docker.
+
+    Home Assistant runs on host network with a persistent config volume.
+    """
+    app_manager = AppManager.get()
+    service_name = "home_assistant"
+    slack_client = SlackClient(
+        app_token=config.slack.app_token,
+        bot_token=config.slack.bot_token,
+        channel_id=config.slack.channel,
+    )
+
+    ha_config = config.home_assistant
+    if not ha_config:
+        raise ValueError("Home Assistant config not defined")
+
+    await _ensure_docker_ready()
+
+    config_dir = _ensure_directories()
+    _seed_default_config(config_dir)
+
+    timezone = os.environ.get("TZ", "UTC")
+
+    docker_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        CONTAINER_NAME,
+        "--network",
+        "host",
+        "--privileged",
+        "-e",
+        f"TZ={timezone}",
+        "-v",
+        f"{config_dir}:/config",
+        HOME_ASSISTANT_IMAGE,
+    ]
+
+    CONSOLE.print(
+        f"Starting Home Assistant container '{CONTAINER_NAME}' "
+        f"with image '{HOME_ASSISTANT_IMAGE}'"
+    )
+    await _remove_existing_container()
+    await app_manager.update_service(
+        service_name,
+        state="running",
+        detail="Starting Home Assistant container",
+    )
+    process = await asyncio.create_subprocess_exec(*docker_cmd)
+    await app_manager.update_service(
+        service_name,
+        state="running",
+        detail="Home Assistant running",
+    )
+
+    ha_port = ha_config.port
+    ha_host = os.environ.get("HOME_ASSISTANT_EXTERNAL_HOST") or (
+        f"http://{config.root.self_ip}:{ha_port}"
+        if config.root.self_ip
+        else f"http://127.0.0.1:{ha_port}"
+    )
+    await slack_client.create_status(f"Home Assistant is now running → {ha_host}")
+    returncode = await process.wait()
+
+    if returncode:
+        await app_manager.update_service(
+            service_name,
+            state="error",
+            detail=f"Home Assistant container exited with code {returncode}",
+        )
+        raise RuntimeError(
+            f"Home Assistant container exited with code {returncode}"
+        )
+    await app_manager.update_service(
+        service_name,
+        state="completed",
+        detail="Home Assistant container stopped",
+    )

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -148,22 +148,34 @@ async def main(config: BungaloConfig) -> None:
         HOME_ASSISTANT_IMAGE,
     ]
 
-    CONSOLE.print(
-        f"Starting Home Assistant container '{CONTAINER_NAME}' "
-        f"with image '{HOME_ASSISTANT_IMAGE}'"
-    )
-    await _remove_existing_container()
+    CONSOLE.print(f"Pulling Home Assistant image '{HOME_ASSISTANT_IMAGE}'")
     await app_manager.update_service(
         service_name,
-        state="running",
-        detail="Starting Home Assistant container",
+        state="pulling",
+        detail=f"Pulling image {HOME_ASSISTANT_IMAGE}",
     )
-    process = await asyncio.create_subprocess_exec(*docker_cmd)
+    pull_process = await asyncio.create_subprocess_exec(
+        "docker", "pull", HOME_ASSISTANT_IMAGE,
+    )
+    pull_rc = await pull_process.wait()
+    if pull_rc:
+        await app_manager.update_service(
+            service_name,
+            state="error",
+            detail=f"Failed to pull image {HOME_ASSISTANT_IMAGE} (exit code {pull_rc})",
+        )
+        raise RuntimeError(
+            f"Failed to pull Home Assistant image (exit code {pull_rc})"
+        )
+
+    CONSOLE.print(f"Starting Home Assistant container '{CONTAINER_NAME}'")
+    await _remove_existing_container()
     await app_manager.update_service(
         service_name,
         state="running",
         detail="Home Assistant running",
     )
+    process = await asyncio.create_subprocess_exec(*docker_cmd)
 
     ha_port = ha_config.port
     ha_host = os.environ.get("HOME_ASSISTANT_EXTERNAL_HOST") or (

--- a/bungalo/plugins/home_assistant.py
+++ b/bungalo/plugins/home_assistant.py
@@ -155,7 +155,9 @@ async def main(config: BungaloConfig) -> None:
         detail=f"Pulling image {HOME_ASSISTANT_IMAGE}",
     )
     pull_process = await asyncio.create_subprocess_exec(
-        "docker", "pull", HOME_ASSISTANT_IMAGE,
+        "docker",
+        "pull",
+        HOME_ASSISTANT_IMAGE,
     )
     pull_rc = await pull_process.wait()
     if pull_rc:
@@ -164,9 +166,7 @@ async def main(config: BungaloConfig) -> None:
             state="error",
             detail=f"Failed to pull image {HOME_ASSISTANT_IMAGE} (exit code {pull_rc})",
         )
-        raise RuntimeError(
-            f"Failed to pull Home Assistant image (exit code {pull_rc})"
-        )
+        raise RuntimeError(f"Failed to pull Home Assistant image (exit code {pull_rc})")
 
     CONSOLE.print(f"Starting Home Assistant container '{CONTAINER_NAME}'")
     await _remove_existing_container()
@@ -192,9 +192,7 @@ async def main(config: BungaloConfig) -> None:
             state="error",
             detail=f"Home Assistant container exited with code {returncode}",
         )
-        raise RuntimeError(
-            f"Home Assistant container exited with code {returncode}"
-        )
+        raise RuntimeError(f"Home Assistant container exited with code {returncode}")
     await app_manager.update_service(
         service_name,
         state="completed",

--- a/bungalo/plugins/home_assistant_seed/__init__.py
+++ b/bungalo/plugins/home_assistant_seed/__init__.py
@@ -1,0 +1,1 @@
+"""Seed configuration files for Home Assistant first-launch setup."""

--- a/bungalo/plugins/home_assistant_seed/automations.yaml
+++ b/bungalo/plugins/home_assistant_seed/automations.yaml
@@ -6,8 +6,8 @@
   alias: "Sunrise Wake-Up Light"
   description: >-
     Gradually turns on a light over 10 minutes, incrementing brightness
-    by 1 point at a time (1→255) while shifting color from warm red
-    through orange and soft yellow to bright daylight white — simulating
+    by 1 point at a time (1→255) while shifting color temperature from
+    warm candlelight (2000K) to bright daylight (6500K) — simulating
     a sunrise to wake you up naturally.
   trigger:
     - platform: time
@@ -19,7 +19,7 @@
         entity_id: light.bedroom
       data:
         brightness: 1
-        rgb_color: [255, 60, 10]
+        color_temp_kelvin: 2000
     - repeat:
         count: 254
         sequence:
@@ -30,8 +30,5 @@
               entity_id: light.bedroom
             data:
               brightness: "{{ repeat.index + 1 }}"
-              rgb_color:
-                - 255
-                - "{{ (60 + (repeat.index / 254 * 195)) | int }}"
-                - "{{ (10 + (repeat.index / 254 * 210)) | int }}"
+              color_temp_kelvin: "{{ (2000 + (repeat.index / 254 * 4500)) | int }}"
   mode: single

--- a/bungalo/plugins/home_assistant_seed/automations.yaml
+++ b/bungalo/plugins/home_assistant_seed/automations.yaml
@@ -1,0 +1,37 @@
+# Bungalo-managed Home Assistant automations
+# This file was seeded by bungalo on first launch.
+# Feel free to modify it — bungalo will not overwrite existing files.
+
+- id: bungalo_sunrise_wake_up
+  alias: "Sunrise Wake-Up Light"
+  description: >-
+    Gradually turns on a light over 10 minutes, incrementing brightness
+    by 1 point at a time (1→255) while shifting color from warm red
+    through orange and soft yellow to bright daylight white — simulating
+    a sunrise to wake you up naturally.
+  trigger:
+    - platform: time
+      at: "07:00:00"
+  condition: []
+  action:
+    - service: light.turn_on
+      target:
+        entity_id: light.bedroom
+      data:
+        brightness: 1
+        rgb_color: [255, 60, 10]
+    - repeat:
+        count: 254
+        sequence:
+          - delay:
+              milliseconds: 2353
+          - service: light.turn_on
+            target:
+              entity_id: light.bedroom
+            data:
+              brightness: "{{ repeat.index + 1 }}"
+              rgb_color:
+                - 255
+                - "{{ (60 + (repeat.index / 254 * 195)) | int }}"
+                - "{{ (10 + (repeat.index / 254 * 210)) | int }}"
+  mode: single

--- a/bungalo/plugins/home_assistant_seed/configuration.yaml
+++ b/bungalo/plugins/home_assistant_seed/configuration.yaml
@@ -1,0 +1,13 @@
+# Bungalo-managed Home Assistant configuration
+# This file was seeded by bungalo on first launch.
+# Feel free to modify it — bungalo will not overwrite existing files.
+
+homeassistant:
+  name: Bungalo Home
+  unit_system: metric
+
+default_config:
+
+automation: !include automations.yaml
+script: !include scripts.yaml
+scene: !include scenes.yaml

--- a/bungalo/plugins/home_assistant_seed/scenes.yaml
+++ b/bungalo/plugins/home_assistant_seed/scenes.yaml
@@ -1,0 +1,4 @@
+# Bungalo-managed Home Assistant scenes
+# This file was seeded by bungalo on first launch.
+# Feel free to modify it — bungalo will not overwrite existing files.
+[]

--- a/bungalo/plugins/home_assistant_seed/scripts.yaml
+++ b/bungalo/plugins/home_assistant_seed/scripts.yaml
@@ -1,0 +1,32 @@
+# Bungalo-managed Home Assistant scripts
+# This file was seeded by bungalo on first launch.
+# Feel free to modify it — bungalo will not overwrite existing files.
+
+sunrise_light:
+  alias: "Sunrise Light (manual)"
+  description: >-
+    Manually trigger the sunrise light sequence — same 10-minute
+    progression incrementing brightness by 1 point at a time (1→255)
+    from warm red to daylight white.
+  sequence:
+    - service: light.turn_on
+      target:
+        entity_id: light.bedroom
+      data:
+        brightness: 1
+        rgb_color: [255, 60, 10]
+    - repeat:
+        count: 254
+        sequence:
+          - delay:
+              milliseconds: 2353
+          - service: light.turn_on
+            target:
+              entity_id: light.bedroom
+            data:
+              brightness: "{{ repeat.index + 1 }}"
+              rgb_color:
+                - 255
+                - "{{ (60 + (repeat.index / 254 * 195)) | int }}"
+                - "{{ (10 + (repeat.index / 254 * 210)) | int }}"
+  mode: single

--- a/bungalo/plugins/home_assistant_seed/scripts.yaml
+++ b/bungalo/plugins/home_assistant_seed/scripts.yaml
@@ -1,32 +1,4 @@
 # Bungalo-managed Home Assistant scripts
 # This file was seeded by bungalo on first launch.
 # Feel free to modify it — bungalo will not overwrite existing files.
-
-sunrise_light:
-  alias: "Sunrise Light (manual)"
-  description: >-
-    Manually trigger the sunrise light sequence — same 10-minute
-    progression incrementing brightness by 1 point at a time (1→255)
-    from warm red to daylight white.
-  sequence:
-    - service: light.turn_on
-      target:
-        entity_id: light.bedroom
-      data:
-        brightness: 1
-        rgb_color: [255, 60, 10]
-    - repeat:
-        count: 254
-        sequence:
-          - delay:
-              milliseconds: 2353
-          - service: light.turn_on
-            target:
-              entity_id: light.bedroom
-            data:
-              brightness: "{{ repeat.index + 1 }}"
-              rgb_color:
-                - 255
-                - "{{ (60 + (repeat.index / 254 * 195)) | int }}"
-                - "{{ (10 + (repeat.index / 254 * 210)) | int }}"
-  mode: single
+[]

--- a/bungalo/plugins/jellyfin.py
+++ b/bungalo/plugins/jellyfin.py
@@ -167,6 +167,7 @@ async def main(config: BungaloConfig) -> None:
     NAS shares via volume mounts.
     """
     app_manager = AppManager.get()
+    AppManager.register_port_check("jellyfin", 8096)
     service_name = "jellyfin"
     slack_client = SlackClient(
         app_token=config.slack.app_token,

--- a/bungalo/plugins/jellyfin.py
+++ b/bungalo/plugins/jellyfin.py
@@ -318,21 +318,36 @@ async def main(config: BungaloConfig) -> None:
             JELLYFIN_IMAGE,
         ]
 
+        CONSOLE.print(f"Pulling Jellyfin image '{JELLYFIN_IMAGE}'")
+        await app_manager.update_service(
+            service_name,
+            state="pulling",
+            detail=f"Pulling image {JELLYFIN_IMAGE}",
+        )
+        pull_process = await asyncio.create_subprocess_exec(
+            "docker", "pull", JELLYFIN_IMAGE,
+        )
+        pull_rc = await pull_process.wait()
+        if pull_rc:
+            await app_manager.update_service(
+                service_name,
+                state="error",
+                detail=f"Failed to pull image {JELLYFIN_IMAGE} (exit code {pull_rc})",
+            )
+            raise RuntimeError(
+                f"Failed to pull Jellyfin image (exit code {pull_rc})"
+            )
+
         CONSOLE.print(
-            f"Starting Jellyfin container '{CONTAINER_NAME}' with image '{JELLYFIN_IMAGE}'"
+            f"Starting Jellyfin container '{CONTAINER_NAME}'"
         )
         await _remove_existing_container()
         await app_manager.update_service(
             service_name,
             state="running",
-            detail="Starting Jellyfin media server container",
-        )
-        process = await asyncio.create_subprocess_exec(*docker_cmd)
-        await app_manager.update_service(
-            service_name,
-            state="running",
             detail="Jellyfin media server running",
         )
+        process = await asyncio.create_subprocess_exec(*docker_cmd)
         jellyfin_host = os.environ.get("JELLYFIN_EXTERNAL_HOST") or (
             f"http://{config.root.self_ip}:8096"
             if config.root.self_ip

--- a/bungalo/plugins/jellyfin.py
+++ b/bungalo/plugins/jellyfin.py
@@ -325,7 +325,9 @@ async def main(config: BungaloConfig) -> None:
             detail=f"Pulling image {JELLYFIN_IMAGE}",
         )
         pull_process = await asyncio.create_subprocess_exec(
-            "docker", "pull", JELLYFIN_IMAGE,
+            "docker",
+            "pull",
+            JELLYFIN_IMAGE,
         )
         pull_rc = await pull_process.wait()
         if pull_rc:
@@ -334,13 +336,9 @@ async def main(config: BungaloConfig) -> None:
                 state="error",
                 detail=f"Failed to pull image {JELLYFIN_IMAGE} (exit code {pull_rc})",
             )
-            raise RuntimeError(
-                f"Failed to pull Jellyfin image (exit code {pull_rc})"
-            )
+            raise RuntimeError(f"Failed to pull Jellyfin image (exit code {pull_rc})")
 
-        CONSOLE.print(
-            f"Starting Jellyfin container '{CONTAINER_NAME}'"
-        )
+        CONSOLE.print(f"Starting Jellyfin container '{CONTAINER_NAME}'")
         await _remove_existing_container()
         await app_manager.update_service(
             service_name,

--- a/bungalo/port_check.py
+++ b/bungalo/port_check.py
@@ -1,0 +1,26 @@
+import asyncio
+
+
+async def _check_port(host: str, port: int, timeout: float = 2.0) -> bool:
+    """Return True if a TCP connection to host:port succeeds within timeout."""
+    try:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=timeout,
+        )
+        writer.close()
+        await writer.wait_closed()
+        return True
+    except (OSError, asyncio.TimeoutError):
+        return False
+
+
+async def check_ports(
+    ports: dict[str, int],
+    host: str = "127.0.0.1",
+) -> dict[str, bool]:
+    """Check reachability for a dict of name→port mappings concurrently."""
+    results = await asyncio.gather(
+        *(_check_port(host, port) for port in ports.values())
+    )
+    return dict(zip(ports.keys(), results))

--- a/bungalo/system_metrics.py
+++ b/bungalo/system_metrics.py
@@ -60,6 +60,7 @@ def _collect_metrics_sync() -> dict[str, Any]:
 
     memory = psutil.virtual_memory()
     swap = psutil.swap_memory()
+    disk = psutil.disk_usage("/")
     processes = _collect_top_processes()
 
     return {
@@ -89,6 +90,12 @@ def _collect_metrics_sync() -> dict[str, Any]:
             "used": swap.used,
             "free": swap.free,
             "percent": swap.percent,
+        },
+        "disk": {
+            "total": disk.total,
+            "used": disk.used,
+            "free": disk.free,
+            "percent": disk.percent,
         },
         "processes": processes,
     }

--- a/bungalo/system_metrics.py
+++ b/bungalo/system_metrics.py
@@ -46,7 +46,16 @@ def _collect_top_processes() -> list[dict[str, Any]]:
 
 
 def _collect_metrics_sync() -> dict[str, Any]:
+    # Snapshot network counters before the CPU sampling delay so we can
+    # compute throughput rates over the same interval.
+    net_before = psutil.net_io_counters()
+    net_time_before = time.monotonic()
+
     cpu_per_core = psutil.cpu_percent(interval=0.1, percpu=True)
+
+    net_after = psutil.net_io_counters()
+    net_elapsed = time.monotonic() - net_time_before
+
     load_average = None
     try:
         load_values = getattr(psutil, "getloadavg", os.getloadavg)()
@@ -96,6 +105,12 @@ def _collect_metrics_sync() -> dict[str, Any]:
             "used": disk.used,
             "free": disk.free,
             "percent": disk.percent,
+        },
+        "network": {
+            "bytes_sent_per_sec": (net_after.bytes_sent - net_before.bytes_sent) / net_elapsed,
+            "bytes_recv_per_sec": (net_after.bytes_recv - net_before.bytes_recv) / net_elapsed,
+            "bytes_sent_total": net_after.bytes_sent,
+            "bytes_recv_total": net_after.bytes_recv,
         },
         "processes": processes,
     }

--- a/bungalo/system_metrics.py
+++ b/bungalo/system_metrics.py
@@ -107,8 +107,10 @@ def _collect_metrics_sync() -> dict[str, Any]:
             "percent": disk.percent,
         },
         "network": {
-            "bytes_sent_per_sec": (net_after.bytes_sent - net_before.bytes_sent) / net_elapsed,
-            "bytes_recv_per_sec": (net_after.bytes_recv - net_before.bytes_recv) / net_elapsed,
+            "bytes_sent_per_sec": (net_after.bytes_sent - net_before.bytes_sent)
+            / net_elapsed,
+            "bytes_recv_per_sec": (net_after.bytes_recv - net_before.bytes_recv)
+            / net_elapsed,
             "bytes_sent_total": net_after.bytes_sent,
             "bytes_recv_total": net_after.bytes_recv,
         },

--- a/config.example.toml
+++ b/config.example.toml
@@ -49,3 +49,6 @@ self_ip = "100.64.0.10"
 [[media_server.mounts]]
   name = "tv"
   path = "nas:unifi-nas://Media/TV"
+
+[home_assistant]
+  # port = 8123  # default Home Assistant port

--- a/config.example.toml
+++ b/config.example.toml
@@ -51,4 +51,5 @@ self_ip = "100.64.0.10"
   path = "nas:unifi-nas://Media/TV"
 
 [home_assistant]
+  enabled = true
   # port = 8123  # default Home Assistant port

--- a/frontend/app/dashboard-client.tsx
+++ b/frontend/app/dashboard-client.tsx
@@ -391,7 +391,7 @@ export function DashboardClient({ host }: { host: string }) {
           </Card>
         ) : null}
 
-        <section className="grid gap-4 md:grid-cols-2">
+        <section className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <Card className="transition-all hover:shadow-lg cursor-pointer">
             <a href="/" className="block">
               <CardHeader>
@@ -407,7 +407,7 @@ export function DashboardClient({ host }: { host: string }) {
           </Card>
 
           <Card className="transition-all hover:shadow-lg cursor-pointer">
-            <a 
+            <a
               href={`http://${hostname}:8096`}
               target="_blank"
               rel="noopener noreferrer"
@@ -422,6 +422,27 @@ export function DashboardClient({ host }: { host: string }) {
                 </div>
                 <CardDescription>
                   Access your media library
+                </CardDescription>
+              </CardHeader>
+            </a>
+          </Card>
+
+          <Card className="transition-all hover:shadow-lg cursor-pointer">
+            <a
+              href={`http://${hostname}:8123`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block"
+            >
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-xl">Home Assistant</CardTitle>
+                  <svg className="h-4 w-4 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </div>
+                <CardDescription>
+                  Home automation and smart devices
                 </CardDescription>
               </CardHeader>
             </a>

--- a/frontend/app/dashboard-client.tsx
+++ b/frontend/app/dashboard-client.tsx
@@ -406,47 +406,49 @@ export function DashboardClient({ host }: { host: string }) {
             </a>
           </Card>
 
-          <Card className="transition-all hover:shadow-lg cursor-pointer">
-            <a
-              href={`http://${hostname}:8096`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block"
-            >
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-xl">Media Server</CardTitle>
-                  <svg className="h-4 w-4 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                  </svg>
-                </div>
-                <CardDescription>
-                  Access your media library
-                </CardDescription>
-              </CardHeader>
-            </a>
-          </Card>
-
-          <Card className="transition-all hover:shadow-lg cursor-pointer">
-            <a
-              href={`http://${hostname}:8123`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="block"
-            >
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-xl">Home Assistant</CardTitle>
-                  <svg className="h-4 w-4 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-                  </svg>
-                </div>
-                <CardDescription>
-                  Home automation and smart devices
-                </CardDescription>
-              </CardHeader>
-            </a>
-          </Card>
+          {(() => {
+            const externalServices = [
+              { key: "jellyfin", title: "Media Server", description: "Access your media library", port: 8096 },
+              { key: "home_assistant", title: "Home Assistant", description: "Home automation and smart devices", port: 8123 },
+            ];
+            const portStatus = data?.port_status ?? {};
+            return externalServices.map((svc) => {
+              const reachable = portStatus[svc.key] ?? false;
+              return (
+                <Card
+                  key={svc.key}
+                  className={`transition-all ${reachable ? "hover:shadow-lg cursor-pointer" : "opacity-50 cursor-default"}`}
+                >
+                  {reachable ? (
+                    <a
+                      href={`http://${hostname}:${svc.port}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block"
+                    >
+                      <CardHeader>
+                        <div className="flex items-center justify-between">
+                          <CardTitle className="text-xl">{svc.title}</CardTitle>
+                          <svg className="h-4 w-4 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                          </svg>
+                        </div>
+                        <CardDescription>{svc.description}</CardDescription>
+                      </CardHeader>
+                    </a>
+                  ) : (
+                    <CardHeader>
+                      <div className="flex items-center justify-between">
+                        <CardTitle className="text-xl">{svc.title}</CardTitle>
+                        <StatusBadge state="offline" />
+                      </div>
+                      <CardDescription>{svc.description}</CardDescription>
+                    </CardHeader>
+                  )}
+                </Card>
+              );
+            });
+          })()}
         </section>
 
         <SystemMetricsCard metrics={data?.system ?? null} />

--- a/frontend/app/dashboard-client.tsx
+++ b/frontend/app/dashboard-client.tsx
@@ -275,6 +275,26 @@ function SystemMetricsCard({
                 </p>
               )}
             </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                Disk
+              </p>
+              <p className="text-lg font-semibold text-foreground">
+                {formatBytes(metrics.disk.used)} /{" "}
+                {formatBytes(metrics.disk.total)}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {Math.min(metrics.disk.percent, 100).toFixed(1)}% used •{" "}
+                {formatBytes(metrics.disk.free)} free
+              </p>
+              <div className="h-2 w-full rounded-full bg-muted">
+                <div
+                  className="h-2 rounded-full bg-violet-500 transition-all"
+                  style={{ width: `${Math.min(metrics.disk.percent, 100)}%` }}
+                />
+              </div>
+            </div>
           </div>
 
           <div className="space-y-3">

--- a/frontend/app/dashboard-client.tsx
+++ b/frontend/app/dashboard-client.tsx
@@ -295,6 +295,29 @@ function SystemMetricsCard({
                 />
               </div>
             </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">
+                Network
+              </p>
+              <div className="flex items-center gap-4">
+                <div className="flex-1">
+                  <p className="text-xs text-muted-foreground">Download</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {formatBytes(metrics.network.bytes_recv_per_sec)}/s
+                  </p>
+                </div>
+                <div className="flex-1">
+                  <p className="text-xs text-muted-foreground">Upload</p>
+                  <p className="text-lg font-semibold text-foreground">
+                    {formatBytes(metrics.network.bytes_sent_per_sec)}/s
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Total: {formatBytes(metrics.network.bytes_recv_total)} down • {formatBytes(metrics.network.bytes_sent_total)} up
+              </p>
+            </div>
           </div>
 
           <div className="space-y-3">

--- a/frontend/components/status-badge.tsx
+++ b/frontend/components/status-badge.tsx
@@ -10,6 +10,7 @@ const statusVariant: Record<string, "default" | "secondary" | "destructive" | "o
   error: "destructive",
   failed: "destructive",
   warning: "outline",
+  offline: "outline",
   pending: "outline",
   submitted: "secondary",
 };

--- a/frontend/components/status-badge.tsx
+++ b/frontend/components/status-badge.tsx
@@ -10,6 +10,7 @@ const statusVariant: Record<string, "default" | "secondary" | "destructive" | "o
   error: "destructive",
   failed: "destructive",
   warning: "outline",
+  pulling: "secondary",
   offline: "outline",
   pending: "outline",
   submitted: "secondary",

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -46,6 +46,12 @@ export interface SystemMetrics {
     free: number;
     percent: number;
   };
+  disk: {
+    total: number;
+    used: number;
+    free: number;
+    percent: number;
+  };
   processes: ProcessMetric[];
 }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -52,6 +52,12 @@ export interface SystemMetrics {
     free: number;
     percent: number;
   };
+  network: {
+    bytes_sent_per_sec: number;
+    bytes_recv_per_sec: number;
+    bytes_sent_total: number;
+    bytes_recv_total: number;
+  };
   processes: ProcessMetric[];
 }
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -71,6 +71,7 @@ export interface AppState {
   services: ServiceStatus[];
   tasks: TaskState[];
   system?: SystemMetrics | SystemMetricsError;
+  port_status?: Record<string, boolean>;
 }
 
 function resolveApiBase(): string {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["bungalo"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"bungalo/plugins/home_assistant_seed" = "bungalo/plugins/home_assistant_seed"
+
 [dependency-groups]
 dev = [
     "pyright>=1.1.399",

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -6,6 +6,15 @@ set -e
 
 echo "Starting Docker daemon for Docker-in-Docker..."
 
+# Clean up stale PID file from a previous container run
+if [ -f /var/run/docker.pid ]; then
+    OLD_PID=$(cat /var/run/docker.pid)
+    if ! kill -0 "$OLD_PID" 2>/dev/null; then
+        echo "Removing stale Docker PID file (PID $OLD_PID no longer running)"
+        rm -f /var/run/docker.pid
+    fi
+fi
+
 # Start Docker daemon in the background
 # Configuration is loaded from /etc/docker/daemon.json
 dockerd >/var/log/dockerd.log 2>&1 &

--- a/setup.sh
+++ b/setup.sh
@@ -22,5 +22,6 @@ docker run -d \
      --cap-add=SYS_ADMIN \
      --device /dev/fuse \
      -v ~/.bungalo:/root/.bungalo \
+     -v ~/.bungalo/docker:/var/lib/docker \
      -v /dev/bus/usb:/dev/bus/usb \
      ghcr.io/piercefreeman/bungalo:latest


### PR DESCRIPTION
Add Home Assistant integration, since it supports more robust automation definitions than equivalent cloud providers like Homekit and Google Home. Our initial script is a time triggered wakeup alarm that progressively turns on the bedroom light.

As part of this PR we also add a host of random improvements to the admin console:

- how readiness status for pulled docker services
- show current disk space utilization
- show current network usage