### PR TITLE
Sync remote backups and retain deleted versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ During steady state operation, we poll for the UPS status from our locally runni
 Our NAS is our network's source of truth for all files. For a full data backup, we conceptually have two separate steps:
 
 1. Cloud -> NAS: Sync proprietary clouds like iCloud, Frame.io, and iPhoto into our local storage.
-2. Syncing the full NAS contents to a remote cloud. We're currently architected with two redundency zones, one in Virginia and one in Amsterdam. We copy these files individually with rclone instead of using "Cloud Replication" so we have a bit more control over encryption keys and notification status of completed syncs.
+2. Syncing the full NAS contents to a remote cloud. We're currently architected with two redundancy zones, one in Virginia and one in Amsterdam. We use [`rclone sync`](https://rclone.org/commands/rclone_sync/) instead of "Cloud Replication" so we have more control over encryption keys and notification status. Sync makes the remote match the NAS, including removing remote files that were deleted locally; rclone suppresses destination deletes if the run encounters errors.
+
+Backblaze B2 keeps deleted files as hidden versions by default. Each backup bucket must have a [lifecycle rule](https://www.backblaze.com/docs/cloud-storage-lifecycle-rules) with `daysFromHidingToDeleting` set to `30`, retaining deleted and overwritten versions for 30 days before permanent deletion. Do not set `daysFromUploadingToHiding`, which would also expire current files that still exist on the NAS. Rclone documents the B2 version and deletion behavior in its [B2 backend guide](https://rclone.org/b2/#versions).
 
 Backups made to remote locations are encrypted via rclone's crypt provider:
 

--- a/bungalo/__tests__/backups/test_remote.py
+++ b/bungalo/__tests__/backups/test_remote.py
@@ -156,7 +156,7 @@ async def test_sync_all_invokes_rclone_and_mount(
     patched_run[1].assert_called_once()
     args, _ = patched_run[1].call_args
     cmd = args[:5]
-    assert cmd[0:2] == ("rclone", "copy")
+    assert cmd[0:2] == ("rclone", "sync")
 
 
 @pytest.mark.asyncio

--- a/bungalo/backups/remote.py
+++ b/bungalo/backups/remote.py
@@ -222,7 +222,7 @@ class RCloneSync:
     async def _run_sync(self, src: str, dst: str, update_status: SlackMessage) -> None:
         process = await asyncio.create_subprocess_exec(
             "rclone",
-            "copy",
+            "sync",
             "--config",
             str(self.config_path),
             src,


### PR DESCRIPTION
## Summary
- switch remote backups from `rclone copy` to `rclone sync` so destination-only files are removed
- document B2 hidden-version retention and the 30-day lifecycle policy
- update the existing rclone command assertion

## Testing
- `uv run pytest bungalo/__tests__/backups/test_remote.py -q`